### PR TITLE
fix #30 不分页时，设置dataPath 无效

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -656,7 +656,8 @@ export default {
 
           // 不分页
           if (!this.hasPagination) {
-            data = _get(res, dataPath) || _get(res, noPaginationDataPath) || []
+            data =
+              _get(res, this.dataPath) || _get(res, noPaginationDataPath) || []
           } else {
             data = _get(res, this.dataPath) || []
             this.total = _get(res, this.totalPath)


### PR DESCRIPTION
fix #30 
修复由于使用默认的dataPath导致的自定义dataPath无效