### PR TITLE
fix: 按钮loading状态私有化，互不影响各自的loading状态

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -15,14 +15,15 @@
             <el-form-item>
                 <el-button v-if="hasNew" type="primary" size="small"
                            @click="onDefaultNew">新增</el-button>
-                <el-button v-for="(btn, i) in headerButtons"
-                           v-if="'show' in btn ? btn.show(selected) : true"
-                           :disabled="'disabled' in btn ? btn.disabled(selected) : false"
-                           @click="onCustomButtonsClick(btn.atClick, selected)"
-                           v-loading="customButtonsLoading"
-                           v-bind="btn"
-                           :key="i"
-                           size="small" >{{btn.text}}</el-button>
+                <el-loading-button v-for="(btn, i) in headerButtons"
+                                   v-if="'show' in btn ? btn.show(selected) : true"
+                                   :disabled="'disabled' in btn ? btn.disabled(selected) : false"
+                                   :click="btn.atClick"
+                                   :params="selected"
+                                   :callback="getList"
+                                   v-bind="btn"
+                                   :key="i"
+                                   size="small" >{{btn.text}}</el-loading-button>
                 <el-button v-if="hasSelect && hasDelete" type="danger" size="small"
                            @click="onDefaultDelete($event)"
                            :disabled="single ? (!selected.length || selected.length > 1) : !selected.length">删除</el-button>
@@ -115,13 +116,17 @@
                                @click="onDefaultView(scope.row)">
                         查看
                     </el-button>
-                    <el-button v-for="(btn, i) in extraButtons"
-                               v-if="'show' in btn ? btn.show(scope.row) : true"
-                               v-bind="btn" @click="onCustomButtonsClick(btn.atClick, scope.row)" :key="i" size="small"
-                               v-loading="customButtonsLoading"
+                    <el-loading-button v-for="(btn, i) in extraButtons"
+                                       v-if="'show' in btn ? btn.show(scope.row) : true"
+                                       v-bind="btn"
+                                       :click="btn.atClick"
+                                       :params="scope.row"
+                                       :callback="getList"
+                                       :key="i"
+                                       size="small"
                     >
                         {{btn.text}}
-                    </el-button>
+                    </el-loading-button>
                     <el-button v-if="!hasSelect && hasDelete && canDelete(scope.row)" type="danger" size="small"
                                @click="onDefaultDelete(scope.row)">
                         删除
@@ -163,6 +168,7 @@
 <script>
 import _get from 'lodash.get'
 import qs from 'qs'
+import ElLoadingButton from './el-loading-button.vue'
 
 // 默认返回的数据格式如下
 //          {
@@ -202,6 +208,9 @@ const queryPattern = new RegExp('q=.*' + paramSeparator)
 
 export default {
   name: 'ElDataTable',
+  components: {
+    ElLoadingButton
+  },
   props: {
     /**
      * 请求url, 如果为空, 则不会发送请求; 改变url, 则table会重新发送请求
@@ -543,8 +552,6 @@ export default {
       total: null,
       loading: false,
       selected: [],
-
-      customButtonsLoading: false,
 
       //弹窗
       dialogTitle: this.dialogNewTitle,
@@ -961,21 +968,6 @@ export default {
       }).catch(er => {
         /*取消*/
       })
-    },
-    onCustomButtonsClick(fn, parameter) {
-      if (!fn) return
-
-      this.customButtonsLoading = true
-
-      fn(parameter)
-        .then(flag => {
-          if (flag === false) return
-          this.getList()
-        })
-        .catch(e => {})
-        .finally(e => {
-          this.customButtonsLoading = false
-        })
     },
     // 树形table相关
     // https://github.com/PanJiaChen/vue-element-admin/tree/master/src/components/TreeTable

--- a/src/el-loading-button.vue
+++ b/src/el-loading-button.vue
@@ -1,0 +1,72 @@
+<template>
+  <el-button v-bind="$attrs"
+             v-on="$listeners"
+             :loading="selfLoading || loading"
+             :type="type"
+             @click="handleClick">
+    <slot></slot>
+  </el-button>
+</template>
+
+<script>
+export default {
+  name: 'ElLoadingButton',
+  props: {
+    /**
+     * 按钮的loading状态
+     * default: false
+     */
+    loading: {
+      type: Boolean
+    },
+    /**
+     * 点击按钮触发的事件
+     * 为什么要用这个传这个事件--如果在组件内部调用this.$emit('click')获取不到回调值（即监控不了promise的进度）
+     */
+    click: {
+      type: Function
+    },
+    /**
+     * 点击事件的回调函数
+     */
+    callback: {
+      type: Function,
+      default: () => {}
+    },
+    /**
+     * 点击事件传入的参数
+     */
+    params: {},
+    /**
+     * 按钮Type,跟el-button的type一致 详见：http://element-cn.eleme.io/#/zh-CN/component/button
+     * 如果不声明props type，在form里会默认加入type=submit覆盖传入的type
+     */
+    type: {
+      type: String
+    }
+  },
+  data() {
+    return {
+      selfLoading: false
+    }
+  },
+  methods: {
+    // 监控按钮的Promise进程
+    handleClick() {
+      if (!this.click) return
+
+      this.selfLoading = true
+      Promise.resolve(this.click(this.params))
+        .then(flag => {
+          if (flag === false) return
+          // 调用父组件中的数据刷新方法
+          this.callback()
+        })
+        .catch(e => {})
+        .finally(e => {
+          this.selfLoading = false
+        })
+    }
+  }
+}
+</script>

--- a/stories/index.js
+++ b/stories/index.js
@@ -12,6 +12,7 @@ import OnDelete from './on-delete.vue'
 import BeforeConfirm from './before-confirm.vue'
 import OnNewOrEdit from './on-new-or-edit.vue'
 import Expand from './expand.vue'
+import LoadingButtons from './loading-buttons.vue'
 
 storiesOf('ElDataTable', module)
   .add('基本CRUD', basic)
@@ -34,6 +35,10 @@ storiesOf('ElDataTable', module)
   .add('expand', () => ({
     components: {Expand},
     template: `<expand/>`
+  }))
+  .add('loading-buttons', () => ({
+    components: {LoadingButtons},
+    template: `<loading-buttons/>`
   }))
 
 function basic() {

--- a/stories/loading-buttons.vue
+++ b/stories/loading-buttons.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <p>每个按钮之间的loading相互独立</p>
+    <el-data-table v-bind="$data"></el-data-table>
+  </div>
+</template>
+<script>
+import ElDataTable from '../src/el-data-table.vue'
+import config from './config'
+
+export default {
+  components: {ElDataTable},
+  data: function() {
+    return {
+      url: config.url,
+      dataPath: config.dataPath,
+      totalPath: config.totalPath,
+      form: config.form,
+      formAttrs: config.formAttrs,
+      columns: [
+        {
+          type: 'selection'
+        }
+      ].concat(config.columns),
+      headerButtons: [
+        {
+          text: '请求后不刷新',
+          atClick: selected => {
+            console.log(selected)
+            return new Promise((resolve, reject) =>
+              setTimeout(() => resolve(false), 1500)
+            )
+          }
+        },
+        {
+          text: '请求后刷新',
+          atClick: selected => {
+            return new Promise((resolve, reject) =>
+              setTimeout(() => resolve(), 1500)
+            )
+          }
+        }
+      ],
+      extraButtons: [
+        {
+          type: 'primary',
+          text: 'Promise1',
+          atClick: row => {
+            console.log(row)
+            return new Promise((resolve, reject) => setTimeout(resolve, 1500))
+          }
+        },
+        {
+          text: 'Promise2',
+          atClick: row => {
+            return new Promise((resolve, reject) => setTimeout(resolve, 1500))
+          }
+        }
+      ],
+      hasEdit: false,
+      hasNew: false,
+      hasDelete: false
+    }
+  },
+  computed: {
+    loading() {
+      return true
+    }
+  }
+}
+</script>


### PR DESCRIPTION
1、将el-button再进行一层封装，通过点击事件的返回来的promise进行请求进度监控；
2、将data-table中的自定义按钮事件处理移到el-loading-button中进行处理