### PR TITLE
fix(self-loading-button): remove warning of property <type>

### DIFF
--- a/src/self-loading-button.vue
+++ b/src/self-loading-button.vue
@@ -2,7 +2,6 @@
   <el-button v-bind="$attrs"
              v-on="$listeners"
              :loading="loading"
-             :type="type"
              @click="handleClick">
     <slot></slot>
   </el-button>


### PR DESCRIPTION
- fix: rendere error because the useless components property
