### PR TITLE
feat: 操作列按钮改成文字按钮

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -147,7 +147,7 @@
             v-if="!hasSelect && hasDelete && canDelete(scope.row)"
             type="text"
             size="small"
-            style="color: #f56c6c"
+            style="color: #E24156"
             @click="onDefaultDelete(scope.row)"
           >删除</el-button>
         </template>

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -126,12 +126,12 @@
         <template slot-scope="scope">
           <el-button
             v-if="isTree && hasNew"
-            type="primary"
+            type="text"
             size="small"
             @click="onDefaultNew(scope.row)"
           >新增</el-button>
-          <el-button v-if="hasEdit" size="small" @click="onDefaultEdit(scope.row)">修改</el-button>
-          <el-button v-if="hasView" type="info" size="small" @click="onDefaultView(scope.row)">查看</el-button>
+          <el-button v-if="hasEdit" type="text" size="small" @click="onDefaultEdit(scope.row)">修改</el-button>
+          <el-button v-if="hasView" type="text" size="small" @click="onDefaultView(scope.row)">查看</el-button>
           <self-loading-button
             v-for="(btn, i) in extraButtons"
             v-if="'show' in btn ? btn.show(scope.row) : true"
@@ -140,12 +140,14 @@
             :params="scope.row"
             :callback="getList"
             :key="i"
+            type="text"
             size="small"
           >{{btn.text}}</self-loading-button>
           <el-button
             v-if="!hasSelect && hasDelete && canDelete(scope.row)"
-            type="danger"
+            type="text"
             size="small"
+            style="color: #f56c6c"
             @click="onDefaultDelete(scope.row)"
           >删除</el-button>
         </template>


### PR DESCRIPTION
## Why
按钮样式新规范，参考ant-design

## How
1. type改成text
2. 删除按钮颜色直接使用ui规范写死。
    - 因为没有合适的element class组合同时解决平时+hover状态的danger颜色
    - 2.8以后的element提供link组件完美解决这个问题
