### PR TITLE
fix: #86 重置搜索框内容时，url携带多余参数

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -221,6 +221,8 @@ const valueSeparatorPattern = new RegExp(valueSeparator, 'g')
 const queryFlag = 'q='
 const queryPattern = new RegExp('q=.*' + paramSeparator)
 
+const resetSearchPattern = /\?.*/
+
 export default {
   name: 'ElDataTable',
   components: {
@@ -771,7 +773,7 @@ export default {
       history.replaceState(
         history.state,
         '',
-        location.href.replace(queryPattern, '')
+        location.href.replace(resetSearchPattern, '')
       )
 
       this.$nextTick(() => {


### PR DESCRIPTION
fix: #86 重置搜索框内容时，url携带多余参数

## Why
匹配url的正则不完整，导致在构造查询url时重复添加`&`字符 

## How
修改正则表达式，使得重置内容后匹配url`?`后所有的字符 
