### PR TITLE
feat: 删除按钮颜色使用class替代style

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -153,13 +153,11 @@
             type="text"
             size="small"
           >{{btn.text}}</self-loading-button>
-          <el-button
+          <text-danger-button
             v-if="!hasSelect && hasDelete && canDelete(scope.row)"
-            type="text"
             size="small"
-            style="color: #E24156"
             @click="onDefaultDelete(scope.row)"
-          >删除</el-button>
+          >删除</text-danger-button>
         </template>
       </el-table-column>
 
@@ -196,6 +194,7 @@
 import _get from 'lodash.get'
 import qs from 'qs'
 import SelfLoadingButton from './self-loading-button.vue'
+import TextDangerButton from './text-danger-button.vue'
 
 // 默认返回的数据格式如下
 //          {
@@ -236,7 +235,8 @@ const queryPattern = new RegExp('q=.*' + paramSeparator)
 export default {
   name: 'ElDataTable',
   components: {
-    SelfLoadingButton
+    SelfLoadingButton,
+    TextDangerButton
   },
   props: {
     /**

--- a/src/text-danger-button.vue
+++ b/src/text-danger-button.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="el-alert--error container">
+    <el-button v-bind="$attrs" v-on="$listeners" type="text" class="button">
+      <slot></slot>
+    </el-button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TextDangerButton'
+}
+</script>
+
+<style lang="stylus" scoped>
+.container
+  display inline-block
+  background-color initial
+  .el-button + &
+    margin-left 10px
+
+.button
+  color inherit
+</style>

--- a/src/text-danger-button.vue
+++ b/src/text-danger-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-alert--error container">
+  <div class="el-alert--error text-danger-button">
     <el-button v-bind="$attrs" v-on="$listeners" type="text" class="button">
       <slot></slot>
     </el-button>
@@ -12,13 +12,13 @@ export default {
 }
 </script>
 
-<style lang="stylus" scoped>
-.container
+<style lang="stylus">
+.text-danger-button
   display inline-block
   background-color initial
   .el-button + &
     margin-left 10px
 
-.button
-  color inherit
+  & > .button
+    color inherit
 </style>


### PR DESCRIPTION
## Why
删除按钮写死style，日后无法随自定义主题的element变化

## How
1. 直接在el-button上写class，无法处理hover的情况
2. 利用color: inherit，在el-button之上包裹📦一层div，就可以解决hover和优先级问题

## Xmind
![image](https://user-images.githubusercontent.com/19591950/57674321-8fe3a480-7651-11e9-894c-a36f30cadd66.png)

