### PR TITLE
docs: 补充event的文档

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -751,8 +751,9 @@ export default {
 
           this.loading = false
           /**
-           * 请求返回, 数据更新后触发, 返回(data, resp) data是渲染table的数据, resp是请求返回的完整response
-           * @event update
+           * 请求返回, 数据更新后触发
+           * @property {object} data - table的数据
+           * @property {object} resp - 请求返回的完整response
            */
           this.$emit('update', data, res)
 
@@ -842,12 +843,13 @@ export default {
       })
 
       /**
-       * 按下重置按钮后触发,
-       * 另外, 当customQuery.sync时, 会重置customQuery
-       * @event reset
+       * 按下重置按钮后触发
        */
       this.$emit('reset')
 
+      /**
+       * 配合customQuery.sync使用
+       */
       this.$emit('update:customQuery', JSON.parse(this.initCustomQuery))
     },
     handleSizeChange(val) {
@@ -895,11 +897,6 @@ export default {
      */
     updateSelected(rows) {
       this.selected = rows
-
-      /**
-       * 多选启用时生效, 返回(selected)已选中行的数组
-       * @event selection-change
-       */
       this.$emit('selection-change', rows)
     },
     /**
@@ -915,9 +912,14 @@ export default {
       } else {
         rows.forEach(r => delete map[r[this.id]])
       }
-      this.selectedMap = map
       // 更新this.selectedMap会自动更新this.selected, 详见`computed`
       // 故此函数看起来没有对selected进行操作，却需要对外emit新的值
+      this.selectedMap = map
+
+      /**
+       * 多选项发生变化
+       * @property {array} rows - 已选中的行数据的数组
+       */
       this.$emit('selection-change', this.selected)
     },
     // 弹窗相关

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -579,7 +579,7 @@ export default {
     },
     /**
      * 外部的注入额外的查询参数, 键值对形式。
-     * 可用.sync修饰，此时重置搜索搜索参数也会重置Query
+     * 可用.sync修饰，此时重置搜索搜索参数也会重置customQuery
      */
     customQuery: {
       type: Object,

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -579,7 +579,7 @@ export default {
     },
     /**
      * 外部的注入额外的查询参数, 键值对形式。
-     * 可用.sync修饰，此时重置搜索搜索参数也会重置customQuery
+     * 可用.sync修饰，此时重置搜索搜索参数也会重置Query
      */
     customQuery: {
       type: Object,
@@ -847,9 +847,6 @@ export default {
        */
       this.$emit('reset')
 
-      /**
-       * 配合customQuery.sync使用
-       */
       this.$emit('update:customQuery', JSON.parse(this.initCustomQuery))
     },
     handleSizeChange(val) {


### PR DESCRIPTION
## Why
同一事件`vue-styleguide`只能识别最后一次`$emit`的注释
```js
/**
 * 你以为这句话会进入文档
 */
this.$emit('event')

this.$emit('event') // 最后一次$emit没注释，结果就是没文档
```