### PR TITLE
feat: 增加属性saveQuery控制开启query保存功能

### DIFF
--- a/docs/save-query.md
+++ b/docs/save-query.md
@@ -1,4 +1,4 @@
-基本用法，包含crud
+通过saveQuery控制页面中只有一个table使用url来保存query参数。saveQuery默认为true
 
 ```vue
 <template>

--- a/docs/save-query.md
+++ b/docs/save-query.md
@@ -1,0 +1,53 @@
+基本用法，包含crud
+
+```vue
+<template>
+  <div>
+    <el-data-table v-bind="$data" />
+    <el-data-table v-bind="$data" :save-query="false" />
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://easy-mock.com/mock/5b586c9dfce1393a862d034d/example/img?a=13',
+      columns: [
+        {prop: 'code', label: '品牌编号'},
+        {prop: 'name', label: '品牌名称'},
+        {prop: 'alias', label: '品牌别名'},
+        {
+          prop: 'status',
+          label: '状态',
+          formatter: row => (row.status === 'normal' ? '启用' : '禁用')
+        }
+      ],
+      form: [
+        {
+          $type: 'input',
+          $id: 'name',
+          label: '品牌名称',
+          rules: [
+            {
+              required: true,
+              message: '请输入品牌名称',
+              trigger: 'blur',
+              transform: v => v && v.trim()
+            }
+          ],
+          $el: {placeholder: '请输入品牌名称'}
+        },
+      ],
+      searchForm: [
+        {
+          $el: {placeholder: '请输入'},
+          label: '品牌名称',
+          $id: 'name',
+          $type: 'input'
+        }
+      ]
+    }
+  }
+}
+</script>
+```

--- a/docs/save-query.md
+++ b/docs/save-query.md
@@ -1,4 +1,5 @@
-通过saveQuery控制页面中只有一个table使用url来保存query参数。saveQuery默认为true
+通过saveQuery控制页面中只有一个table使用url来保存query参数。saveQuery默认为true。
+以下示例中，第一个table会saveQuery为true, 第二个saveQuery为false
 
 ```vue
 <template>

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -574,6 +574,9 @@ export default {
         return {}
       }
     },
+    /**
+     * 是否开启使用url保存query参数的功能
+     */
     saveQuery: {
       type: Boolean,
       default: true

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -301,7 +301,8 @@ export default {
       }
     },
     /**
-     * 路由模式, hash | history || '', 决定了查询参数存放的形式, 设置为空则不存储查询参数
+     * 可选值：'hash' | 'history', 当开启 saveQuery 时，决定了查询参数存放的形式
+     * @deprecated
      */
     routerMode: {
       type: String,
@@ -647,7 +648,7 @@ export default {
     }
   },
   mounted() {
-    if (this.saveQuery) {
+    if (this.routerMode && this.saveQuery) {
       const query = queryUtil.get(location.href)
       if (query) {
         this.page = parseInt(query.page)
@@ -784,7 +785,7 @@ export default {
       this.page = defaultFirstPage
 
       // 重置
-      if (this.saveQuery) {
+      if (this.routerMode && this.saveQuery) {
         const newUrl = queryUtil.clear(location.href)
         history.replaceState(history.state, '', newUrl)
       }


### PR DESCRIPTION
## Why
当页面中有多个table时，query参数会互相影响

## How
通过saveQuery属性开关query的功能。一般来说页面中只有一个table可以开启saveQuery

## Test
https://deploy-preview-139--el-data-table.netlify.com/#!/save-query/1

