### PR TITLE
feat: 增加no-data slot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ yarn-error.log*
 dist
 docs/build
 docs/index.html
+docs/*.woff
+docs/*.ttf
 
 # Editor directories and files
 .idea

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -1,6 +1,7 @@
-noData插槽<br>
-以下示例中，第一个table第一次请求时没有数据时就显示no-data的slot;<br>
-而第二个table第一次查询返回有数据的，第二次用户名输入nodata还是显示table，不显示no-data slot
+slot=no-data, 只在第一次请求获取数据为空时显示<br>
+以下示例中
+- 第一个table第一次请求时数据为空，显示了 no-data slot <br>
+- 第二个table第一次请求时数据不为空，则就算之后搜索没有数据，也不会显示 no-data slot
 
 ```vue
 <template>

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -11,7 +11,7 @@ noData插槽<br>
         v-bind="tableConfig"
         :url="url"
       >
-        <template slot="noData">
+        <template slot="no-data">
           <div class="no-data">没有数据，请去添加数据</div>
         </template>
       </el-data-table>

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -19,6 +19,7 @@ noData插槽<br>
   </div>
 </template>
 <script>
+const mockUrl = 'https://easy-mock.com/mock/5c1b3895fe5907404e654045/femessage-mock/el-data-table/'
 export default {
   data() {
     return {
@@ -46,8 +47,8 @@ export default {
         saveQuery:false
       },
       urls: [
-        'https://easy-mock.com/mock/5d240d912102c0666393d262/mock/no-data',
-        'http://yapi.demo.qunar.com/mock/78092/get-data'
+        mockUrl + 'no-data',
+        mockUrl + 'has-data'
       ]
     }
   }

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -1,18 +1,28 @@
-no-data插槽
+noData插槽<br>
+以下示例中，第一个table第一次请求时没有数据时就显示noData的slot
 
 ```vue
 <template>
-  <el-data-table
-    v-bind="$data"
-  >
-    <template slot="noData">
-      <el-row>
-        <el-col :span="8">_</el-col>
-        <el-col :span="8">没有数据，请去添加数据</el-col>
-        <el-col :span="8">_</el-col>
-      </el-row>
-    </template>
-  </el-data-table>
+  <div>
+    <div>第一个table</div>
+    <el-data-table
+      v-bind="$data"
+    >
+      <template slot="noData">
+        <div class="no-data">没有数据，请去添加数据</div>
+      </template>
+    </el-data-table>
+    <div>第二个table</div>
+    <div class="tip">第一次查询返回有数据的，第二次用户名输入nodata还是显示table，不显示no-data slot</div>
+    <el-data-table
+      v-bind="$data"
+      url="http://yapi.demo.qunar.com/mock/78092/get-data"
+    >
+      <template slot="noData">
+        <div class="no-data">没有数据，请去添加数据</div>
+      </template>
+    </el-data-table>
+  </div> 
 </template>
 <script>
 export default {
@@ -33,15 +43,7 @@ export default {
           id: 'q',
           label: '用户名',
           width: '200px',
-          el: {placeholder: '其输入'},
-          default: 'user'
-        },
-        {
-          type: 'input',
-          id: 'q2',
-          label: '标签',
-          width: '200px',
-          el: {placeholder: '其输入'}
+          el: {placeholder: '输入nodata查询'}
         }
       ],
       hasEdit: false,
@@ -51,4 +53,14 @@ export default {
   }
 }
 </script>
+<style>
+.no-data{
+  padding: 32px 0;
+  text-align:center;
+  font-weight:600;
+}
+.tip{
+  padding-bottom: 16px;
+}
+</style>
 ```

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -1,5 +1,5 @@
 noData插槽<br>
-以下示例中，第一个table第一次请求时没有数据时就显示noData的slot;<br>
+以下示例中，第一个table第一次请求时没有数据时就显示no-data的slot;<br>
 而第二个table第一次查询返回有数据的，第二次用户名输入nodata还是显示table，不显示no-data slot
 
 ```vue

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -1,54 +1,54 @@
 noData插槽<br>
-以下示例中，第一个table第一次请求时没有数据时就显示noData的slot
+以下示例中，第一个table第一次请求时没有数据时就显示noData的slot;<br>
+而第二个table第一次查询返回有数据的，第二次用户名输入nodata还是显示table，不显示no-data slot
 
 ```vue
 <template>
   <div>
-    <div>第一个table</div>
-    <el-data-table
-      v-bind="$data"
-    >
-      <template slot="noData">
-        <div class="no-data">没有数据，请去添加数据</div>
-      </template>
-    </el-data-table>
-    <div>第二个table</div>
-    <div class="tip">第一次查询返回有数据的，第二次用户名输入nodata还是显示table，不显示no-data slot</div>
-    <el-data-table
-      v-bind="$data"
-      url="http://yapi.demo.qunar.com/mock/78092/get-data"
-    >
-      <template slot="noData">
-        <div class="no-data">没有数据，请去添加数据</div>
-      </template>
-    </el-data-table>
-  </div> 
+    <template v-for="(url,index) in urls" :key="url">
+      <div>第{{index + 1}}个table</div>
+      <el-data-table
+        v-bind="tableConfig"
+        :url="url"
+      >
+        <template slot="noData">
+          <div class="no-data">没有数据，请去添加数据</div>
+        </template>
+      </el-data-table>
+    </template>
+  </div>
 </template>
 <script>
 export default {
   data() {
     return {
-      url: 'https://easy-mock.com/mock/5d240d912102c0666393d262/mock/no-data',
-      dataPath: 'payload.content',
-      totalPath: 'payload.totalElements',
-      columns: [
-        {prop: 'id', label: 'id'},
-        {prop: 'login', label: '名称'},
-        {prop: 'type', label: '账户类型'},
-        {prop: 'html_url', label: '主页地址'}
-      ],
-      searchForm: [
-        {
-          type: 'input',
-          id: 'q',
-          label: '用户名',
-          width: '200px',
-          el: {placeholder: '输入nodata查询'}
-        }
-      ],
-      hasEdit: false,
-      hasNew: false,
-      hasDelete: false,
+      tableConfig:{
+        dataPath: 'payload.content',
+        totalPath: 'payload.totalElements',
+        columns: [
+          {prop: 'id', label: 'id'},
+          {prop: 'login', label: '名称'},
+          {prop: 'type', label: '账户类型'},
+          {prop: 'html_url', label: '主页地址'}
+        ],
+        searchForm: [
+          {
+            type: 'input',
+            id: 'q',
+            label: '用户名',
+            width: '200px',
+            el: {placeholder: '输入nodata查询'}
+          }
+        ],
+        hasEdit: false,
+        hasNew: false,
+        hasDelete: false,
+        saveQuery:false
+      },
+      urls: [
+        'https://easy-mock.com/mock/5d240d912102c0666393d262/mock/no-data',
+        'http://yapi.demo.qunar.com/mock/78092/get-data'
+      ]
     }
   }
 }

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -1,0 +1,54 @@
+no-data插槽
+
+```vue
+<template>
+  <el-data-table
+    v-bind="$data"
+  >
+    <template slot="noData">
+      <el-row>
+        <el-col :span="8">_</el-col>
+        <el-col :span="8">没有数据，请去添加数据</el-col>
+        <el-col :span="8">_</el-col>
+      </el-row>
+    </template>
+  </el-data-table>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://easy-mock.com/mock/5d240d912102c0666393d262/mock/no-data',
+      dataPath: 'payload.content',
+      totalPath: 'payload.totalElements',
+      columns: [
+        {prop: 'id', label: 'id'},
+        {prop: 'login', label: '名称'},
+        {prop: 'type', label: '账户类型'},
+        {prop: 'html_url', label: '主页地址'}
+      ],
+      searchForm: [
+        {
+          type: 'input',
+          id: 'q',
+          label: '用户名',
+          width: '200px',
+          el: {placeholder: '其输入'},
+          default: 'user'
+        },
+        {
+          type: 'input',
+          id: 'q2',
+          label: '标签',
+          width: '200px',
+          el: {placeholder: '其输入'}
+        }
+      ],
+      hasEdit: false,
+      hasNew: false,
+      hasDelete: false,
+    }
+  }
+}
+</script>
+```

--- a/docs/slot-no-data.md
+++ b/docs/slot-no-data.md
@@ -5,7 +5,7 @@ noData插槽<br>
 ```vue
 <template>
   <div>
-    <template v-for="(url,index) in urls" :key="url">
+    <template v-for="(url,index) in urls">
       <div>第{{index + 1}}个table</div>
       <el-data-table
         v-bind="tableConfig"

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="el-data-table">
-    <template v-if="needToShowNoDataSlot">
+    <template v-if="showNoData">
       <!--@slot 获取数据为空时的内容-->
-      <slot name="noData"></slot>
+      <slot name="no-data"></slot>
     </template>
     <template v-else>
       <!-- @submit.native.prevent -->
@@ -668,7 +668,7 @@ export default {
       // JSON.stringify是为了后面深拷贝作准备
       initExtraQuery: JSON.stringify(this.extraQuery || this.customQuery || {}),
       isSearchCollapse: false,
-      needToShowNoDataSlot: false
+      showNoData: false
     }
   },
   computed: {
@@ -728,7 +728,7 @@ export default {
 
     this.$nextTick(() => {
       this.getList().then(() => {
-        this.needToShowNoDataSlot = this.$slots.noData && this.total === 0
+        this.showNoData = this.$slots['no-data'] && this.total === 0
       })
     })
   },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <div class="el-data-table">
+    <div class="el-data-table" v-if="needToShowNoDataSlot">
       <!--@slot 获取数据为空时的内容-->
       <slot name="noData"></slot>
     </div>
-    <div class="el-data-table">
+    <div class="el-data-table" v-else>
     <!-- @submit.native.prevent -->
     <!-- 阻止表单提交的默认行为 -->
     <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
@@ -685,6 +685,12 @@ export default {
     },
     selectStrategy() {
       return getSelectStrategy(this)
+    },
+    needToShowNoDataSlot() {
+      if (!this.$slots.noData) {
+        return false
+      }
+      return this.total === 0
     }
   },
   watch: {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1,205 +1,205 @@
 <template>
-  <div>
-    <div class="el-data-table" v-if="needToShowNoDataSlot">
+  <div class="el-data-table">
+    <template v-if="needToShowNoDataSlot">
       <!--@slot 获取数据为空时的内容-->
       <slot name="noData"></slot>
-    </div>
-    <div class="el-data-table" v-else>
-    <!-- @submit.native.prevent -->
-    <!-- 阻止表单提交的默认行为 -->
-    <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
-    <!--搜索字段-->
-    <el-form-renderer
-      v-if="hasSearchForm"
-      v-show="!isSearchCollapse"
-      inline
-      :content="searchForm"
-      ref="searchForm"
-      @submit.native.prevent
-    >
-      <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
-      <slot name="search"></slot>
-      <el-form-item>
-        <!--https://github.com/ElemeFE/element/pull/5920-->
-        <el-button native-type="submit" type="primary" @click="search" size="small">查询</el-button>
-        <el-button @click="resetSearch" size="small">重置</el-button>
-      </el-form-item>
-    </el-form-renderer>
-
-    <el-form v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse">
-      <el-form-item>
-        <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
-        <self-loading-button
-          v-for="(btn, i) in headerButtons"
-          v-if="'show' in btn ? btn.show(selected) : true"
-          :disabled="'disabled' in btn ? btn.disabled(selected) : false"
-          :click="btn.atClick"
-          :params="selected"
-          :callback="getList"
-          v-bind="btn"
-          :key="i"
-          size="small"
-        >
-          {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
-        </self-loading-button>
-        <el-button
-          v-if="hasSelect && hasDelete"
-          type="danger"
-          size="small"
-          @click="onDefaultDelete($event)"
-          :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
-        >删除</el-button>
-        <el-button
-          v-if="canSearchCollapse"
-          type="default"
-          size="small"
-          :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
-          @click="isSearchCollapse = !isSearchCollapse"
-        >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
-      </el-form-item>
-    </el-form>
-
-    <el-table
-      ref="table"
-      v-bind="tableAttrs"
-      :data="data"
-      :row-style="showRow"
-      v-loading="loading"
-      @selection-change="selectStrategy.onSelectionChange"
-      @select="selectStrategy.onSelect"
-      @select-all="selectStrategy.onSelectAll"
-    >
-      <!--TODO 不用jsx写, 感觉template逻辑有点不清晰了-->
-      <template v-if="isTree">
-        <!--有多选-->
-        <template v-if="hasSelect">
-          <el-table-column key="selection-key" v-bind="columns[0]"></el-table-column>
-
-          <el-table-column key="tree-ctrl" v-bind="columns[1]">
-            <template slot-scope="scope">
-              <span
-                v-if="isTree"
-                v-for="space in scope.row._level"
-                class="ms-tree-space"
-                :key="space"
-              ></span>
-              <span
-                v-if="isTree && iconShow(scope.$index, scope.row)"
-                class="tree-ctrl"
-                @click="toggleExpanded(scope.$index)"
-              >
-                <i v-if="!scope.row._expanded" class="el-icon-plus"></i>
-                <i v-else class="el-icon-minus"></i>
-              </span>
-              {{scope.row[columns[1].prop]}}
-            </template>
-          </el-table-column>
-
-          <el-table-column
-            v-for="(col) in columns.filter((c, i) => i !== 0 && i !== 1)"
-            :key="col.prop"
-            v-bind="col"
-          ></el-table-column>
-        </template>
-
-        <!--无选择-->
-        <template v-else>
-          <!--展开这列, 丢失 el-table-column属性-->
-          <el-table-column key="tree-ctrl" v-bind="columns[0]">
-            <template slot-scope="scope">
-              <span
-                v-if="isTree"
-                v-for="space in scope.row._level"
-                class="ms-tree-space"
-                :key="space"
-              ></span>
-              <span
-                v-if="isTree && iconShow(scope.$index, scope.row)"
-                class="tree-ctrl"
-                @click="toggleExpanded(scope.$index)"
-              >
-                <i v-if="!scope.row._expanded" class="el-icon-plus"></i>
-                <i v-else class="el-icon-minus"></i>
-              </span>
-              {{scope.row[columns[0].prop]}}
-            </template>
-          </el-table-column>
-
-          <el-table-column
-            v-for="(col) in columns.filter((c, i) => i !== 0)"
-            :key="col.prop"
-            v-bind="col"
-          ></el-table-column>
-        </template>
-      </template>
-
-      <!--非树-->
-      <template v-else>
-        <el-table-column v-for="(col) in columns" :key="col.prop" v-bind="col"></el-table-column>
-      </template>
-
-      <!--默认操作列-->
-      <el-table-column label="操作" v-if="hasOperation" v-bind="operationAttrs">
-        <template slot-scope="scope">
-          <text-button
-            v-if="isTree && hasNew"
-            @click="onDefaultNew(scope.row)"
-          >{{ newText }}</text-button>
-          <text-button
-            v-if="hasEdit"
-            @click="onDefaultEdit(scope.row)"
-          >{{ editText }}</text-button>
-          <text-button
-            v-if="hasView"
-            @click="onDefaultView(scope.row)"
-          >{{ viewText }}</text-button>
-          <self-loading-button
-            v-for="(btn, i) in extraButtons"
-            v-if="'show' in btn ? btn.show(scope.row) : true"
-            v-bind="btn"
-            :click="btn.atClick"
-            :params="scope.row"
-            :callback="getList"
-            :key="i"
-            is-text
-          >
-            {{typeof btn.text === 'function' ? btn.text(scope.row) : btn.text}}
-          </self-loading-button>
-          <text-button
-            v-if="!hasSelect && hasDelete && canDelete(scope.row)"
-            type="danger"
-            @click="onDefaultDelete(scope.row)"
-          >删除</text-button>
-        </template>
-      </el-table-column>
-
-      <!--@slot 自定义操作列, 当extraButtons不满足需求时可以使用 -->
-      <slot></slot>
-    </el-table>
-    <el-pagination
-      v-if="hasPagination"
-      @size-change="handleSizeChange"
-      @current-change="handleCurrentChange"
-      :current-page="page"
-      :page-sizes="paginationSizes"
-      :page-size="size"
-      :total="total"
-      style="text-align: right; padding: 10px 0"
-      :layout="paginationLayout"
-    ></el-pagination>
-    <el-dialog :title="dialogTitle" :visible.sync="dialogVisible" v-if="hasDialog">
-      <!--https://github.com/FEMessage/el-form-renderer-->
-      <el-form-renderer :content="form" ref="dialogForm" v-bind="formAttrs" :disabled="isView">
-        <!--@slot 额外的弹窗表单内容, 当form不满足需求时可以使用，参考：https://femessage.github.io/el-form-renderer/#/Demo?id=slot -->
-        <slot name="form"></slot>
+    </template>
+    <template v-else>
+      <!-- @submit.native.prevent -->
+      <!-- 阻止表单提交的默认行为 -->
+      <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
+      <!--搜索字段-->
+      <el-form-renderer
+        v-if="hasSearchForm"
+        v-show="!isSearchCollapse"
+        inline
+        :content="searchForm"
+        ref="searchForm"
+        @submit.native.prevent
+      >
+        <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
+        <slot name="search"></slot>
+        <el-form-item>
+          <!--https://github.com/ElemeFE/element/pull/5920-->
+          <el-button native-type="submit" type="primary" @click="search" size="small">查询</el-button>
+          <el-button @click="resetSearch" size="small">重置</el-button>
+        </el-form-item>
       </el-form-renderer>
 
-      <div slot="footer" v-show="!isView">
-        <el-button @click="cancel" size="small">取 消</el-button>
-        <el-button type="primary" @click="confirm" :loading="confirmLoading" size="small">确 定</el-button>
-      </div>
-    </el-dialog>
-  </div>
+      <el-form v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse">
+        <el-form-item>
+          <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
+          <self-loading-button
+            v-for="(btn, i) in headerButtons"
+            v-if="'show' in btn ? btn.show(selected) : true"
+            :disabled="'disabled' in btn ? btn.disabled(selected) : false"
+            :click="btn.atClick"
+            :params="selected"
+            :callback="getList"
+            v-bind="btn"
+            :key="i"
+            size="small"
+          >
+            {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
+          </self-loading-button>
+          <el-button
+            v-if="hasSelect && hasDelete"
+            type="danger"
+            size="small"
+            @click="onDefaultDelete($event)"
+            :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
+          >删除</el-button>
+          <el-button
+            v-if="canSearchCollapse"
+            type="default"
+            size="small"
+            :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
+            @click="isSearchCollapse = !isSearchCollapse"
+          >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
+        </el-form-item>
+      </el-form>
+
+      <el-table
+        ref="table"
+        v-bind="tableAttrs"
+        :data="data"
+        :row-style="showRow"
+        v-loading="loading"
+        @selection-change="selectStrategy.onSelectionChange"
+        @select="selectStrategy.onSelect"
+        @select-all="selectStrategy.onSelectAll"
+      >
+        <!--TODO 不用jsx写, 感觉template逻辑有点不清晰了-->
+        <template v-if="isTree">
+          <!--有多选-->
+          <template v-if="hasSelect">
+            <el-table-column key="selection-key" v-bind="columns[0]"></el-table-column>
+
+            <el-table-column key="tree-ctrl" v-bind="columns[1]">
+              <template slot-scope="scope">
+                <span
+                  v-if="isTree"
+                  v-for="space in scope.row._level"
+                  class="ms-tree-space"
+                  :key="space"
+                ></span>
+                <span
+                  v-if="isTree && iconShow(scope.$index, scope.row)"
+                  class="tree-ctrl"
+                  @click="toggleExpanded(scope.$index)"
+                >
+                  <i v-if="!scope.row._expanded" class="el-icon-plus"></i>
+                  <i v-else class="el-icon-minus"></i>
+                </span>
+                {{scope.row[columns[1].prop]}}
+              </template>
+            </el-table-column>
+
+            <el-table-column
+              v-for="(col) in columns.filter((c, i) => i !== 0 && i !== 1)"
+              :key="col.prop"
+              v-bind="col"
+            ></el-table-column>
+          </template>
+
+          <!--无选择-->
+          <template v-else>
+            <!--展开这列, 丢失 el-table-column属性-->
+            <el-table-column key="tree-ctrl" v-bind="columns[0]">
+              <template slot-scope="scope">
+                <span
+                  v-if="isTree"
+                  v-for="space in scope.row._level"
+                  class="ms-tree-space"
+                  :key="space"
+                ></span>
+                <span
+                  v-if="isTree && iconShow(scope.$index, scope.row)"
+                  class="tree-ctrl"
+                  @click="toggleExpanded(scope.$index)"
+                >
+                  <i v-if="!scope.row._expanded" class="el-icon-plus"></i>
+                  <i v-else class="el-icon-minus"></i>
+                </span>
+                {{scope.row[columns[0].prop]}}
+              </template>
+            </el-table-column>
+
+            <el-table-column
+              v-for="(col) in columns.filter((c, i) => i !== 0)"
+              :key="col.prop"
+              v-bind="col"
+            ></el-table-column>
+          </template>
+        </template>
+
+        <!--非树-->
+        <template v-else>
+          <el-table-column v-for="(col) in columns" :key="col.prop" v-bind="col"></el-table-column>
+        </template>
+
+        <!--默认操作列-->
+        <el-table-column label="操作" v-if="hasOperation" v-bind="operationAttrs">
+          <template slot-scope="scope">
+            <text-button
+              v-if="isTree && hasNew"
+              @click="onDefaultNew(scope.row)"
+            >{{ newText }}</text-button>
+            <text-button
+              v-if="hasEdit"
+              @click="onDefaultEdit(scope.row)"
+            >{{ editText }}</text-button>
+            <text-button
+              v-if="hasView"
+              @click="onDefaultView(scope.row)"
+            >{{ viewText }}</text-button>
+            <self-loading-button
+              v-for="(btn, i) in extraButtons"
+              v-if="'show' in btn ? btn.show(scope.row) : true"
+              v-bind="btn"
+              :click="btn.atClick"
+              :params="scope.row"
+              :callback="getList"
+              :key="i"
+              is-text
+            >
+              {{typeof btn.text === 'function' ? btn.text(scope.row) : btn.text}}
+            </self-loading-button>
+            <text-button
+              v-if="!hasSelect && hasDelete && canDelete(scope.row)"
+              type="danger"
+              @click="onDefaultDelete(scope.row)"
+            >删除</text-button>
+          </template>
+        </el-table-column>
+
+        <!--@slot 自定义操作列, 当extraButtons不满足需求时可以使用 -->
+        <slot></slot>
+      </el-table>
+      <el-pagination
+        v-if="hasPagination"
+        @size-change="handleSizeChange"
+        @current-change="handleCurrentChange"
+        :current-page="page"
+        :page-sizes="paginationSizes"
+        :page-size="size"
+        :total="total"
+        style="text-align: right; padding: 10px 0"
+        :layout="paginationLayout"
+      ></el-pagination>
+      <el-dialog :title="dialogTitle" :visible.sync="dialogVisible" v-if="hasDialog">
+        <!--https://github.com/FEMessage/el-form-renderer-->
+        <el-form-renderer :content="form" ref="dialogForm" v-bind="formAttrs" :disabled="isView">
+          <!--@slot 额外的弹窗表单内容, 当form不满足需求时可以使用，参考：https://femessage.github.io/el-form-renderer/#/Demo?id=slot -->
+          <slot name="form"></slot>
+        </el-form-renderer>
+
+        <div slot="footer" v-show="!isView">
+          <el-button @click="cancel" size="small">取 消</el-button>
+          <el-button type="primary" @click="confirm" :loading="confirmLoading" size="small">确 定</el-button>
+        </div>
+      </el-dialog>
+    </template>
   </div>
 </template>
 
@@ -667,7 +667,8 @@ export default {
       // 初始的extraQuery值, 重置查询时, 会用到
       // JSON.stringify是为了后面深拷贝作准备
       initExtraQuery: JSON.stringify(this.extraQuery || this.customQuery || {}),
-      isSearchCollapse: false
+      isSearchCollapse: false,
+      needToShowNoDataSlot: false
     }
   },
   computed: {
@@ -685,12 +686,6 @@ export default {
     },
     selectStrategy() {
       return getSelectStrategy(this)
-    },
-    needToShowNoDataSlot() {
-      if (!this.$slots.noData) {
-        return false
-      }
-      return this.total === 0
     }
   },
   watch: {
@@ -732,7 +727,9 @@ export default {
     }
 
     this.$nextTick(() => {
-      this.getList()
+      this.getList().then(() => {
+        this.needToShowNoDataSlot = this.$slots.noData && this.total === 0
+      })
     })
   },
   methods: {
@@ -746,7 +743,7 @@ export default {
 
       if (!url) {
         console.warn('DataTable: url 为空, 不发送请求')
-        return
+        return Promise.resolve()
       }
 
       // 构造query对象
@@ -777,7 +774,15 @@ export default {
       // 请求开始
       this.loading = true
 
-      this.$axios
+      // 存储query记录, 便于后面恢复
+      if (saveQuery) {
+        // 存储的page是table的页码，无需偏移
+        query.page = this.page
+        const newUrl = queryUtil.set(location.href, query, this.routerMode)
+        history.pushState(history.state, 'el-data-table search', newUrl)
+      }
+
+      return this.$axios
         .get(url + queryStr)
         .then(({data: resp}) => {
           let data = []
@@ -821,14 +826,6 @@ export default {
           this.$emit('error', err)
           this.loading = false
         })
-
-      // 存储query记录, 便于后面恢复
-      if (saveQuery) {
-        // 存储的page是table的页码，无需偏移
-        query.page = this.page
-        const newUrl = queryUtil.set(location.href, query, this.routerMode)
-        history.pushState(history.state, 'el-data-table search', newUrl)
-      }
     },
     search() {
       this.$refs.searchForm.validate(valid => {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="el-data-table">
+  <div>
+    <div class="el-data-table">
+      <!--@slot 获取数据为空时的内容-->
+      <slot name="noData"></slot>
+    </div>
+    <div class="el-data-table">
     <!-- @submit.native.prevent -->
     <!-- 阻止表单提交的默认行为 -->
     <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
@@ -194,6 +199,7 @@
         <el-button type="primary" @click="confirm" :loading="confirmLoading" size="small">确 定</el-button>
       </div>
     </el-dialog>
+  </div>
   </div>
 </template>
 

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -669,8 +669,8 @@ export default {
       initExtraQuery: JSON.stringify(this.extraQuery || this.customQuery || {}),
       isSearchCollapse: false,
       showNoData: false,
-      // 第一次请求flag
-      isFirstGetList: true
+      // 是否请求过flag
+      hasRequest: false
     }
   },
   computed: {
@@ -806,10 +806,10 @@ export default {
             this.data = this.tree2Array(data, this.expandAll)
           }
 
-          // 第一次getList
-          if (this.isFirstGetList) {
+          // 没有请求过
+          if (!this.hasRequest) {
             this.showNoData = this.$slots['no-data'] && this.total === 0
-            this.isFirstGetList = false
+            this.hasRequest = true
           }
 
           this.loading = false


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why
当从url首次请求到数据为空时，显示自定义内容为空的内容

## How
例如：获取内容为空时：显示自定义内容不显示table，search form，page.
         
![image](https://user-images.githubusercontent.com/19562649/60949478-e30f6600-a327-11e9-828e-bc9ac1ed91e4.png)
  
无查询条件获取内容非空时：正常显示
     
![image](https://user-images.githubusercontent.com/19562649/60949507-ee629180-a327-11e9-9955-87ae1820c3d6.png)

非首次查询条件为空时：正常显示
     
![image](https://user-images.githubusercontent.com/19562649/60949539-f8849000-a327-11e9-8c8c-e4d2c103e529.png)



## Test
### 1. 组件内没有slot时，不影响原来逻辑。
### 2. 组件内有slot时
   
  1. 第一次查询时
    1. 获取数据total字段为0，显示slot内容，不显示其余内容。
    2. 获取数据total字段不为0，不显示slot内容，显示原有内容。

   2. 非首次查询时，获取数据total字段为0，不显示slot内容，显示原有内容。

## Docs
docs/slot-no-data.md
