### PR TITLE
feat: 增加header-slot

### DIFF
--- a/docs/slot-header.md
+++ b/docs/slot-header.md
@@ -1,0 +1,45 @@
+header插槽，作用域传入selected数组
+
+```vue
+<template>
+  <el-data-table
+    v-bind="$data"
+  >
+    <template v-slot:header="{selected}">
+      <el-tag>slot=header{{selected.length}}</el-tag>
+      <el-dropdown>
+        <el-button type="primary" size="small">
+          更多菜单<i class="el-icon-arrow-down el-icon--right"></i>
+        </el-button>
+        <el-dropdown-menu slot="dropdown">
+          <el-dropdown-item>黄金糕</el-dropdown-item>
+          <el-dropdown-item>狮子头</el-dropdown-item>
+          <el-dropdown-item>螺蛳粉</el-dropdown-item>
+          <el-dropdown-item>双皮奶</el-dropdown-item>
+          <el-dropdown-item>蚵仔煎</el-dropdown-item>
+        </el-dropdown-menu>
+      </el-dropdown>
+    </template>
+  </el-data-table>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://easy-mock.com/mock/5b586c9dfce1393a862d034d/example/img?a=slotheader',
+      columns: [
+        {type: 'selection'},
+        {prop: 'code', label: '品牌编号'},
+        {prop: 'name', label: '品牌名称'},
+        {prop: 'alias', label: '品牌别名'},
+        {
+          prop: 'status',
+          label: '状态',
+          formatter: row => (row.status === 'normal' ? '启用' : '禁用')
+        }
+      ],
+    }
+  }
+}
+</script>
+```

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -26,38 +26,38 @@
         </el-form-item>
       </el-form-renderer>
 
-      <el-form v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse">
-        <el-form-item>
-          <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
-          <self-loading-button
-            v-for="(btn, i) in headerButtons"
-            v-if="'show' in btn ? btn.show(selected) : true"
-            :disabled="'disabled' in btn ? btn.disabled(selected) : false"
-            :click="btn.atClick"
-            :params="selected"
-            :callback="getList"
-            v-bind="btn"
-            :key="i"
-            size="small"
-          >
-            {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
-          </self-loading-button>
-          <el-button
-            v-if="hasSelect && hasDelete"
-            type="danger"
-            size="small"
-            @click="onDefaultDelete($event)"
-            :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
-          >删除</el-button>
-          <el-button
-            v-if="canSearchCollapse"
-            type="default"
-            size="small"
-            :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
-            @click="isSearchCollapse = !isSearchCollapse"
-          >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
-        </el-form-item>
-      </el-form>
+      <div v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse" style="margin-bottom: 22px">
+        <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
+        <self-loading-button
+          v-for="(btn, i) in headerButtons"
+          v-if="'show' in btn ? btn.show(selected) : true"
+          :disabled="'disabled' in btn ? btn.disabled(selected) : false"
+          :click="btn.atClick"
+          :params="selected"
+          :callback="getList"
+          v-bind="btn"
+          :key="i"
+          size="small"
+        >
+          {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
+        </self-loading-button>
+        <el-button
+          v-if="hasSelect && hasDelete"
+          type="danger"
+          size="small"
+          @click="onDefaultDelete($event)"
+          :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
+        >删除</el-button>
+        <el-button
+          v-if="canSearchCollapse"
+          type="default"
+          size="small"
+          :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
+          @click="isSearchCollapse = !isSearchCollapse"
+        >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
+        <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
+        <slot name="header" v-bind:selected="selected" />
+      </div>
 
       <el-table
         ref="table"

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -57,7 +57,7 @@
             @click="isSearchCollapse = !isSearchCollapse"
           >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
           <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
-          <slot name="header" v-bind:selected="selected" />
+          <slot name="header" :selected="selected" />
         </el-form-item>
       </el-form>
 

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -26,38 +26,40 @@
         </el-form-item>
       </el-form-renderer>
 
-      <div v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse" style="margin-bottom: 22px">
-        <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
-        <self-loading-button
-          v-for="(btn, i) in headerButtons"
-          v-if="'show' in btn ? btn.show(selected) : true"
-          :disabled="'disabled' in btn ? btn.disabled(selected) : false"
-          :click="btn.atClick"
-          :params="selected"
-          :callback="getList"
-          v-bind="btn"
-          :key="i"
-          size="small"
-        >
-          {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
-        </self-loading-button>
-        <el-button
-          v-if="hasSelect && hasDelete"
-          type="danger"
-          size="small"
-          @click="onDefaultDelete($event)"
-          :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
-        >删除</el-button>
-        <el-button
-          v-if="canSearchCollapse"
-          type="default"
-          size="small"
-          :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
-          @click="isSearchCollapse = !isSearchCollapse"
-        >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
-        <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
-        <slot name="header" v-bind:selected="selected" />
-      </div>
+      <el-form v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse">
+        <el-form-item>
+          <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
+          <self-loading-button
+            v-for="(btn, i) in headerButtons"
+            v-if="'show' in btn ? btn.show(selected) : true"
+            :disabled="'disabled' in btn ? btn.disabled(selected) : false"
+            :click="btn.atClick"
+            :params="selected"
+            :callback="getList"
+            v-bind="btn"
+            :key="i"
+            size="small"
+          >
+            {{typeof btn.text === 'function' ? btn.text(selected) : btn.text}}
+          </self-loading-button>
+          <el-button
+            v-if="hasSelect && hasDelete"
+            type="danger"
+            size="small"
+            @click="onDefaultDelete($event)"
+            :disabled="single ? (!selected.length || selected.length > 1) : !selected.length"
+          >删除</el-button>
+          <el-button
+            v-if="canSearchCollapse"
+            type="default"
+            size="small"
+            :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
+            @click="isSearchCollapse = !isSearchCollapse"
+          >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
+          <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
+          <slot name="header" v-bind:selected="selected" />
+        </el-form-item>
+      </el-form>
 
       <el-table
         ref="table"


### PR DESCRIPTION
## Why
resolve #175 , close #103

## How
在header末尾增加作用域插槽slot=header，传入selected

## Test
打开preview中[slot-header章节](https://deploy-preview-177--el-data-table.netlify.com/#!/slot-header/1)，查看效果

## Docs
1. api文档增加slot=header介绍
2. demo中增加slot-header案例
