### PR TITLE
perf: 优化监听弹窗关闭的方式

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -189,7 +189,7 @@
         :layout="paginationLayout"
       ></el-pagination>
 
-      <el-dialog :title="dialogTitle" :visible.sync="dialogVisible" v-if="hasDialog">
+      <el-dialog :title="dialogTitle" :visible.sync="dialogVisible" v-if="hasDialog" @close="handleDialogClose">
         <!--https://github.com/FEMessage/el-form-renderer-->
         <el-form-renderer :content="form" ref="dialogForm" v-bind="formAttrs" :disabled="isView">
           <!--@slot 额外的弹窗表单内容, 当form不满足需求时可以使用，参考：https://femessage.github.io/el-form-renderer/#/Demo?id=slot -->
@@ -716,13 +716,6 @@ export default {
       },
       immediate: true
     },
-    dialogVisible: function(val, old) {
-      if (!val) {
-        this.confirmLoading = false
-
-        this.$refs.dialogForm.resetFields()
-      }
-    },
     selected(val) {
       /**
        * 多选项发生变化
@@ -945,6 +938,10 @@ export default {
     },
     cancel() {
       this.dialogVisible = false
+    },
+    handleDialogClose() {
+      this.confirmLoading = false
+      this.$refs.dialogForm.resetFields()
     },
     confirm() {
       this.$refs.dialogForm.validate(valid => {


### PR DESCRIPTION
## Why
使用 el-dialog 实现的 close 事件更好，不需自己使用 watch 监听

## How
1. 删掉 watch dialogVisible 的代码
2. 监听 el-dialog 的 close 事件

![E58AD9CC-96FE-4b09-8AEC-E100EBF7C3BD](https://user-images.githubusercontent.com/26338853/61764123-a30db000-ae0a-11e9-9fd0-625ed3f4ce22.png)

## Test
关闭弹窗时，能够正常执行相应操作（重置表单，确定按钮的 loading 重置成 false）

## Docs
无需文档修改