### PR TITLE
fix: 修复 tr 淡入动画没添加上

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -63,7 +63,7 @@
         ref="table"
         v-bind="tableAttrs"
         :data="data"
-        :row-style="showRow"
+        :row-class-name="showRow"
         v-loading="loading"
         @selection-change="selectStrategy.onSelectionChange"
         @select="selectStrategy.onSelect"
@@ -1104,9 +1104,7 @@ export default {
         ? row.row.parent._expanded && row.row.parent._show
         : true
       row.row._show = show
-      return show
-        ? 'animation:treeTableShow 1s-webkit-animation:treeTableShow 1s'
-        : 'display:none'
+      return show ? 'row-show' : 'row-hide'
     },
     // 切换下级是否展开
     toggleExpanded(trIndex) {
@@ -1168,6 +1166,14 @@ export default {
     to {
       opacity: 1;
     }
+  }
+
+  .row-show {
+    animation: treeTableShow 1s;
+  }
+
+  .row-hide {
+    display: none;
   }
 }
 </style>


### PR DESCRIPTION
## Why
原 showRow 方法想要给显示的行(tr)加一个淡入的动画，但是由于没有用 ";" 分隔，导致没加上，tr 也就没有淡入效果
![F141C48A-27CC-4d64-AD20-8324AD01A68A](https://user-images.githubusercontent.com/26338853/61868944-17c91300-af0d-11e9-9469-7d0b33515d3c.png)


## How
1. 用 row-class-name 代替 row-style
2. 用添加相应类名的方式代替内联样式

![tablenaotu](https://user-images.githubusercontent.com/26338853/61868800-c587f200-af0c-11e9-9c2d-54dea343f621.png)


## Test
1. 能够正确给行加上淡入动画，显示时能有淡入效果
2. 对于 isTree 类型，能够正确控制行的显示与隐藏

- Before
![before](https://user-images.githubusercontent.com/26338853/61868988-30d1c400-af0d-11e9-9a8b-51945f02ee62.gif)

- After
![after](https://user-images.githubusercontent.com/26338853/61869013-3deeb300-af0d-11e9-967b-cec4b3f5fb98.gif)


## Docs
无需文档修改
