### PR TITLE
fix: header 在没有头部按钮时出现 22px 高度的问题

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -26,7 +26,7 @@
         </el-form-item>
       </el-form-renderer>
 
-      <el-form v-if="hasNew || hasDelete || headerButtons.length > 0 || canSearchCollapse">
+      <el-form v-if="hasHeader">
         <el-form-item>
           <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
           <self-loading-button
@@ -676,6 +676,14 @@ export default {
     },
     hasSearchForm() {
       return this.searchForm.length || this.$slots.search
+    },
+    hasHeader() {
+      return (
+        this.hasNew ||
+        (this.hasSelect && hasDelete) ||
+        this.headerButtons.length ||
+        this.canSearchCollapse
+      )
     },
     _extraBody() {
       return this.extraBody || this.extraParams || {}


### PR DESCRIPTION
## Why
fix #182 
header的判定条件不完备导致的

## How
抽离hasHeader逻辑，且`hasSelect && hasDelete`时才构成header存在的充分条件（非必要）

## Test
设置`hasNew: false`
### Before
![image](https://user-images.githubusercontent.com/19591950/62033876-89f86b00-b21f-11e9-8e69-630d147ac238.png)

### After
![image](https://user-images.githubusercontent.com/19591950/62033943-a5fc0c80-b21f-11e9-9406-d8674403d62a.png)
