### PR TITLE
fix: hash变化时table的数据未更新

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -21,14 +21,26 @@
         <slot name="search"></slot>
         <el-form-item>
           <!--https://github.com/ElemeFE/element/pull/5920-->
-          <el-button native-type="submit" type="primary" @click="search" size="small">查询</el-button>
+          <el-button
+            native-type="submit"
+            type="primary"
+            @click="search"
+            size="small"
+            >查询</el-button
+          >
           <el-button @click="resetSearch" size="small">重置</el-button>
         </el-form-item>
       </el-form-renderer>
 
       <el-form v-if="hasHeader">
         <el-form-item>
-          <el-button v-if="hasNew" type="primary" size="small" @click="onDefaultNew">{{ newText }}</el-button>
+          <el-button
+            v-if="hasNew"
+            type="primary"
+            size="small"
+            @click="onDefaultNew"
+            >{{ newText }}</el-button
+          >
           <self-loading-button
             v-for="(btn, i) in headerButtons"
             v-if="'show' in btn ? btn.show(selected) : true"
@@ -40,9 +52,7 @@
             :key="i"
             size="small"
           >
-            {{
-            typeof btn.text === 'function' ? btn.text(selected) : btn.text
-            }}
+            {{ typeof btn.text === 'function' ? btn.text(selected) : btn.text }}
           </self-loading-button>
           <el-button
             v-if="hasSelect && hasDelete"
@@ -54,14 +64,16 @@
                 ? !selected.length || selected.length > 1
                 : !selected.length
             "
-          >删除</el-button>
+            >删除</el-button
+          >
           <el-button
             v-if="canSearchCollapse"
             type="default"
             size="small"
             :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
             @click="isSearchCollapse = !isSearchCollapse"
-          >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button>
+            >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button
+          >
           <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
           <slot name="header" :selected="selected" />
         </el-form-item>
@@ -81,7 +93,10 @@
         <template v-if="isTree">
           <!--有多选-->
           <template v-if="hasSelect">
-            <el-table-column key="selection-key" v-bind="columns[0]"></el-table-column>
+            <el-table-column
+              key="selection-key"
+              v-bind="columns[0]"
+            ></el-table-column>
 
             <el-table-column key="tree-ctrl" v-bind="columns[1]">
               <template slot-scope="scope">
@@ -143,15 +158,31 @@
 
         <!--非树-->
         <template v-else>
-          <el-table-column v-for="col in columns" :key="col.prop" v-bind="col"></el-table-column>
+          <el-table-column
+            v-for="col in columns"
+            :key="col.prop"
+            v-bind="col"
+          ></el-table-column>
         </template>
 
         <!--默认操作列-->
-        <el-table-column label="操作" v-if="hasOperation" v-bind="operationAttrs">
+        <el-table-column
+          label="操作"
+          v-if="hasOperation"
+          v-bind="operationAttrs"
+        >
           <template slot-scope="scope">
-            <text-button v-if="isTree && hasNew" @click="onDefaultNew(scope.row)">{{ newText }}</text-button>
-            <text-button v-if="hasEdit" @click="onDefaultEdit(scope.row)">{{ editText }}</text-button>
-            <text-button v-if="hasView" @click="onDefaultView(scope.row)">{{ viewText }}</text-button>
+            <text-button
+              v-if="isTree && hasNew"
+              @click="onDefaultNew(scope.row)"
+              >{{ newText }}</text-button
+            >
+            <text-button v-if="hasEdit" @click="onDefaultEdit(scope.row)">{{
+              editText
+            }}</text-button>
+            <text-button v-if="hasView" @click="onDefaultView(scope.row)">{{
+              viewText
+            }}</text-button>
             <self-loading-button
               v-for="(btn, i) in extraButtons"
               v-if="'show' in btn ? btn.show(scope.row) : true"
@@ -163,14 +194,15 @@
               is-text
             >
               {{
-              typeof btn.text === 'function' ? btn.text(scope.row) : btn.text
+                typeof btn.text === 'function' ? btn.text(scope.row) : btn.text
               }}
             </self-loading-button>
             <text-button
               v-if="!hasSelect && hasDelete && canDelete(scope.row)"
               type="danger"
               @click="onDefaultDelete(scope.row)"
-            >删除</text-button>
+              >删除</text-button
+            >
           </template>
         </el-table-column>
 
@@ -729,14 +761,21 @@ export default {
      */
     updateFromQuery() {
       const query = queryUtil.get(location.href)
-      if (!query) return
-      this.page = parseInt(query.page)
-      this.size = parseInt(query.size)
-      // 恢复查询条件，但对slot=search无效
-      if (this.$refs.searchForm) {
-        delete query.page
-        delete query.size
-        this.$refs.searchForm.updateForm(query)
+      if (query) {
+        this.page = parseInt(query.page)
+        this.size = parseInt(query.size)
+        // 恢复查询条件，但对slot=search无效
+        if (this.$refs.searchForm) {
+          delete query.page
+          delete query.size
+          this.$refs.searchForm.updateForm(query)
+        }
+      } else {
+        this.size = this.paginationSize || this.paginationSizes[0]
+        this.page = defaultFirstPage
+        if (this.$refs.searchForm) {
+          this.$refs.searchForm.resetFields()
+        }
       }
       this.$nextTick(this.getList)
     },
@@ -1094,9 +1133,8 @@ export default {
 </script>
 <style lang="stylus">
 .el-data-table {
-  color-blue = #2196F3;
-  space-width = 18px;
-
+  color-blue = #2196F3
+  space-width = 18px
   .ms-tree-space {
     position: relative;
     top: 1px;

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -679,7 +679,7 @@ export default {
     hasHeader() {
       return (
         this.hasNew ||
-        (this.hasSelect && hasDelete) ||
+        (this.hasSelect && this.hasDelete) ||
         this.headerButtons.length ||
         this.canSearchCollapse
       )
@@ -714,20 +714,32 @@ export default {
   },
   mounted() {
     if (this.saveQuery) {
-      const query = queryUtil.get(location.href)
-      if (query) {
-        this.page = parseInt(query.page)
-        this.size = parseInt(query.size)
-        // 恢复查询条件，但对slot=search无效
-        if (this.$refs.searchForm) {
-          delete query.page
-          delete query.size
-          this.$refs.searchForm.updateForm(query)
-        }
-      }
+      this.updateFromQuery()
+      window.addEventListener('hashchange', this.updateFromQuery)
+    }
+  },
+  destroyed() {
+    if (this.saveQuery) {
+      window.removeEventListener('hashchange', this.updateFromQuery)
     }
   },
   methods: {
+    /**
+     * 从query中获取搜索值、页码等数据，然后发出请求
+     */
+    updateFromQuery() {
+      const query = queryUtil.get(location.href)
+      if (!query) return
+      this.page = parseInt(query.page)
+      this.size = parseInt(query.size)
+      // 恢复查询条件，但对slot=search无效
+      if (this.$refs.searchForm) {
+        delete query.page
+        delete query.size
+        this.$refs.searchForm.updateForm(query)
+      }
+      this.$nextTick(this.getList)
+    },
     /**
      * 手动刷新列表数据
      * @public


### PR DESCRIPTION
## Why
fix #186 
切换hash时，el-data-table没有相应的更新

## How
1. 监听hashchange事件，在事件handler中获取query数据，并更新table

## Test
通过浏览器前进后退来更改hash，table可作出页码、searchForm等的更新
![fix-save-query](https://user-images.githubusercontent.com/19591950/62607736-24982e80-b931-11e9-857d-645327b20433.gif)

但 #162 又复现，还是得通过debounce一劳永逸解决
![image](https://user-images.githubusercontent.com/19591950/62608248-1b5b9180-b932-11e9-840a-76c9ef061610.png)

