### PR TITLE
fix:重置按钮无法清除Request URL中自定义的查询条件

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -881,6 +881,14 @@ export default {
      * @public
      */
     resetSearch() {
+      /**
+       * 按下重置按钮后触发
+       */
+      this.$emit('reset')
+
+      this.$emit('update:customQuery', JSON.parse(this.initExtraQuery))
+      this.$emit('update:extraQuery', JSON.parse(this.initExtraQuery))
+
       // reset后, form里的值会变成 undefined, 在下一次查询会赋值给query
       this.$refs.searchForm.resetFields()
       this.page = defaultFirstPage
@@ -894,14 +902,6 @@ export default {
       this.$nextTick(() => {
         this.getList()
       })
-
-      /**
-       * 按下重置按钮后触发
-       */
-      this.$emit('reset')
-
-      this.$emit('update:customQuery', JSON.parse(this.initExtraQuery))
-      this.$emit('update:extraQuery', JSON.parse(this.initExtraQuery))
     },
     handleSizeChange(val) {
       if (this.size === val) return


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why
使用自定义的搜索条件，重置按钮不可清除request url的自定义查询条件
## How
1. 源代码中重置获取列表的功能先于reset事件和update：extraQuery事件
2. 将reset事件和update：extraQuery事件置于获取列表的功能的前面

## Test

- before
![19_57_25__08_08_2019](https://user-images.githubusercontent.com/16565919/62701436-d1001080-ba16-11e9-9fd5-c743098ce389.jpg)

- after
![19_59_13__08_08_2019](https://user-images.githubusercontent.com/16565919/62701496-0a388080-ba17-11e9-9338-3ebbee80c8ae.jpg)

