### PR TITLE
feat: 支持设置对话框属性 dialogAttrs

### DIFF
--- a/src/components/the-dialog.vue
+++ b/src/components/the-dialog.vue
@@ -3,6 +3,7 @@
     :title="title"
     :visible.sync="visible"
     ref="dialog"
+    v-bind="dialogAttrs"
     @close="resetFields"
   >
     <!--https://github.com/FEMessage/el-form-renderer-->
@@ -55,6 +56,10 @@ export default {
       required: true
     },
     formAttrs: {
+      type: Object,
+      required: true
+    },
+    dialogAttrs: {
       type: Object,
       required: true
     }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -229,6 +229,7 @@
         :viewTitle="dialogViewTitle"
         :form="form"
         :formAttrs="formAttrs"
+        :dialogAttrs="dialogAttrs"
         ref="dialog"
         @confirm="onConfirm"
       >
@@ -615,6 +616,16 @@ export default {
      * @link https://element.eleme.cn/2.4/#/zh-CN/component/form#form-attributes
      */
     formAttrs: {
+      type: Object,
+      default() {
+        return {}
+      }
+    },
+    /**
+     * 对话框属性设置, 详情配置参考element-ui官网
+     * @link https://element.eleme.cn/2.4/#/zh-CN/component/dialog#attributes
+     */
+    dialogAttrs: {
       type: Object,
       default() {
         return {}


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why
#200 之前提出的增加 el-dialog 的width，close-on-click-modal等属性的设置

## How
Describe your steps:
增加dialogAttrs属性

You may use xmind or other mind map to show you logic

## Test
Show your test case

you'd better show `before` and `after` 

## Docs
https://element.eleme.cn/#/zh-CN/component/dialog#attributes
```
dialogAttrs: {
    width: "80%",
    closeOnClickModal: false
},
```
