### PR TITLE
feat: searchForm 内容支持属性 collapsible=false，在搜索区域折叠后仍可见

### DIFF
--- a/docs/search-collapse-always-display.md
+++ b/docs/search-collapse-always-display.md
@@ -18,14 +18,14 @@ export default {
         {
           type: 'input',
           id: 'name',
-          label: '用户名',
+          label: '您的用户名',
+          alwaysDisplay: true,
           el: {placeholder: '请输入用户名'}
         },
         {
           type: 'select',
           id: 'age',
           label: '年龄',
-          alwaysDisplay: true,
           el: {
             placeholder: '请输入年龄'
           },
@@ -35,6 +35,27 @@ export default {
             },
             {
               value: 18
+            }
+          ]
+        },
+        {
+          type: 'input',
+          id: 'favorite',
+          label: '喜欢的东西'
+        },
+        {
+          type: 'input',
+          id: 'wishTravel',
+          label: '想去的地方'
+        },
+        {
+          type: 'select',
+          id: 'lived',
+          label: '待过的地方',
+          options: [
+            {
+              label: '三番',
+              value: 'San Francisco'
             }
           ]
         }

--- a/docs/search-collapse-always-display.md
+++ b/docs/search-collapse-always-display.md
@@ -2,10 +2,7 @@ search表单折叠并且设置部分总是可见
 
 ```vue
 <template>
-  <div>
-    <el-data-table v-bind="$data" ref="table" />
-    <button @click="setOptions">setoptions</button>
-  </div>
+  <el-data-table v-bind="$data" ref="table" />
 </template>
 <script>
 export default {
@@ -44,16 +41,7 @@ export default {
       ],
       canSearchCollapse: true
     }
-  },
-  methods: {
-    setOptions() {
-      this.$refs.table.$refs.searchForm.setOptions('age', [
-        {
-          value: 20
-        }
-      ])
-    }
-  },
+  }
 }
 </script>
 ```

--- a/docs/search-collapse-always-display.md
+++ b/docs/search-collapse-always-display.md
@@ -1,0 +1,59 @@
+search表单折叠并且设置部分总是可见
+
+```vue
+<template>
+  <div>
+    <el-data-table v-bind="$data" ref="table" />
+    <button @click="setOptions">setoptions</button>
+  </div>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://easy-mock.com/mock/5b586c9dfce1393a862d034d/example/img?a=1',
+      columns: [
+        {prop: 'name', label: '用户名'},
+        {prop: 'createdBy', label: '创建人'},
+        {prop: 'userInfo.createTime', label: '创建时间'}
+      ],
+      searchForm: [
+        {
+          type: 'input',
+          id: 'name',
+          label: '用户名',
+          el: {placeholder: '请输入用户名'}
+        },
+        {
+          type: 'select',
+          id: 'age',
+          label: '年龄',
+          alwaysDisplay: true,
+          el: {
+            placeholder: '请输入年龄'
+          },
+          options: [
+            {
+              value: 17
+            },
+            {
+              value: 18
+            }
+          ]
+        }
+      ],
+      canSearchCollapse: true
+    }
+  },
+  methods: {
+    setOptions() {
+      this.$refs.table.$refs.searchForm.setOptions('age', [
+        {
+          value: 20
+        }
+      ])
+    }
+  },
+}
+</script>
+```

--- a/docs/search-item-collapsible.md
+++ b/docs/search-item-collapsible.md
@@ -19,7 +19,7 @@ export default {
           type: 'input',
           id: 'name',
           label: '您的用户名',
-          alwaysDisplay: true,
+          collapsible: false,
           el: {placeholder: '请输入用户名'}
         },
         {

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -61,7 +61,7 @@ export default {
     isSearchCollapse(collapse) {
       this.syncFormValue(
         this.currentForm,
-        !collapse ? 'unCollapsibleForm' : 'normalForm'
+        collapse ? 'normalForm' : 'unCollapsibleForm'
       )
     }
   },

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -61,7 +61,10 @@ export default {
   },
 
   mounted() {
-    formValue = {}
+    formValue = Object.assign(
+      {},
+      this.$refs.mainForm.getFormValue()
+    )
     unwatchMainForm = this.$refs.mainForm.$watch('value', val => {
       formValue = Object.assign(formValue, val)
     })

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -17,7 +17,7 @@
     <el-form-renderer
       v-if="unCollapsibleForm"
       v-show="isSearchCollapse"
-      ref="alwaysDisplayForm"
+      ref="unCollapsibleForm"
       inline
       :content="unCollapsibleContent"
       @submit.native.prevent
@@ -30,7 +30,7 @@
 <script>
 let formValue = {}
 let unwatchNormalForm
-let unwatchAlwaysDisplayForm
+let unwatchUnCollapsibleForm
 
 export default {
   name: 'SearchForm',
@@ -57,7 +57,7 @@ export default {
       )
     },
     currentForm() {
-      return this.isSearchCollapse ? 'alwaysDisplayForm' : 'normalForm'
+      return this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
     }
   },
 
@@ -76,7 +76,7 @@ export default {
       formValue = Object.assign(formValue, val)
     })
     if (this.canSearchCollapse) {
-      unwatchAlwaysDisplayForm = this.$refs.alwaysDisplayForm.$watch(
+      unwatchUnCollapsibleForm = this.$refs.unCollapsibleForm.$watch(
         'value',
         val => {
           formValue = Object.assign(formValue, val)
@@ -88,7 +88,7 @@ export default {
   beforeDestroy() {
     unwatchNormalForm()
     if (this.canSearchCollapse) {
-      unwatchAlwaysDisplayForm()
+      unwatchUnCollapsibleForm()
     }
   },
 
@@ -101,7 +101,7 @@ export default {
       formValue = {}
       this.$refs.normalForm.resetFields()
       if (this.canSearchCollapse) {
-        this.$refs.alwaysDisplayForm.resetFields()
+        this.$refs.unCollapsibleForm.resetFields()
       }
     },
 
@@ -109,7 +109,7 @@ export default {
       formValue = Object.assign(formValue, value)
       this.$refs.normalForm.updateForm(formValue)
       if (this.canSearchCollapse) {
-        this.$refs.alwaysDisplayForm.updateForm(formValue)
+        this.$refs.unCollapsibleForm.updateForm(formValue)
       }
     },
 
@@ -120,7 +120,7 @@ export default {
     setOptions(id, options) {
       this.$refs.normalForm.setOptions(id, options)
       if (this.canSearchCollapse) {
-        this.$refs.alwaysDisplayForm.setOptions(id, options)
+        this.$refs.unCollapsibleForm.setOptions(id, options)
       }
     }
   }

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -61,6 +61,7 @@ export default {
   },
 
   mounted() {
+    formValue = {}
     unwatchMainForm = this.$refs.mainForm.$watch('value', val => {
       formValue = Object.assign(formValue, val)
     })
@@ -74,7 +75,7 @@ export default {
     }
   },
 
-  destroyed() {
+  beforeDestroy() {
     unwatchMainForm()
     if (this.canSearchCollapse) {
       unwatchAlwaysDisplayForm()

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -6,7 +6,7 @@
     <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
     <el-form-renderer
       v-show="!isSearchCollapse"
-      ref="mainForm"
+      ref="normalForm"
       inline
       :content="$table.searchForm"
       @submit.native.prevent
@@ -29,7 +29,7 @@
 
 <script>
 let formValue = {}
-let unwatchMainForm
+let unwatchNormalForm
 let unwatchAlwaysDisplayForm
 
 export default {
@@ -50,7 +50,7 @@ export default {
       return this.$table.isSearchCollapse
     },
     currentForm() {
-      return this.isSearchCollapse ? 'alwaysDisplayForm' : 'mainForm'
+      return this.isSearchCollapse ? 'alwaysDisplayForm' : 'normalForm'
     }
   },
 
@@ -63,9 +63,9 @@ export default {
   mounted() {
     formValue = Object.assign(
       {},
-      this.$refs.mainForm.getFormValue()
+      this.$refs.normalForm.getFormValue()
     )
-    unwatchMainForm = this.$refs.mainForm.$watch('value', val => {
+    unwatchNormalForm = this.$refs.normalForm.$watch('value', val => {
       formValue = Object.assign(formValue, val)
     })
     if (this.canSearchCollapse) {
@@ -79,7 +79,7 @@ export default {
   },
 
   beforeDestroy() {
-    unwatchMainForm()
+    unwatchNormalForm()
     if (this.canSearchCollapse) {
       unwatchAlwaysDisplayForm()
     }
@@ -92,7 +92,7 @@ export default {
 
     resetFields() {
       formValue = {}
-      this.$refs.mainForm.resetFields()
+      this.$refs.normalForm.resetFields()
       if (this.canSearchCollapse) {
         this.$refs.alwaysDisplayForm.resetFields()
       }
@@ -100,7 +100,7 @@ export default {
 
     updateForm(value) {
       formValue = Object.assign(formValue, value)
-      this.$refs.mainForm.updateForm(formValue)
+      this.$refs.normalForm.updateForm(formValue)
       if (this.canSearchCollapse) {
         this.$refs.alwaysDisplayForm.updateForm(formValue)
       }
@@ -111,8 +111,10 @@ export default {
     },
 
     setOptions(id, options) {
-      this.$refs.mainForm.setOptions(id, options)
-      this.$refs.alwaysDisplayForm.setOptions(id, options)
+      this.$refs.normalForm.setOptions(id, options)
+      if (this.canSearchCollapse) {
+        this.$refs.alwaysDisplayForm.setOptions(id, options)
+      }
     }
   }
 }

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -59,9 +59,9 @@ export default {
 
   watch: {
     isSearchCollapse(collapse) {
-      this.updateFormValue(
+      this.syncFormValue(
         this.currentForm,
-        !this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
+        !collapse ? 'unCollapsibleForm' : 'normalForm'
       )
     }
   },
@@ -95,7 +95,7 @@ export default {
       return this.$refs.normalForm.getFormValue()
     },
 
-    updateFormValue(activeForm, inactiveForm) {
+    syncFormValue(activeForm, inactiveForm) {
       if (this.hasUnCollapsibleForm) {
         this.$refs[activeForm].updateForm(
           this.$refs[inactiveForm].getFormValue()

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -1,0 +1,115 @@
+<template>
+  <div>
+    <!-- 搜索字段 -->
+    <!-- @submit.native.prevent -->
+    <!-- 阻止表单提交的默认行为 -->
+    <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
+    <el-form-renderer
+      v-show="!isSearchCollapse"
+      ref="mainForm"
+      inline
+      :content="$table.searchForm"
+      @submit.native.prevent
+    >
+      <slot />
+    </el-form-renderer>
+
+    <el-form-renderer
+      v-if="canSearchCollapse"
+      v-show="isSearchCollapse"
+      ref="alwaysDisplayForm"
+      inline
+      :content="alwaysDisplayContent"
+      @submit.native.prevent
+    >
+      <slot />
+    </el-form-renderer>
+  </div>
+</template>
+
+<script>
+let formValue = {}
+let unwatchMainForm
+let unwatchAlwaysDisplayForm
+
+export default {
+  name: 'SearchForm',
+
+  inject: ['$table'],
+
+  computed: {
+    alwaysDisplayContent() {
+      return this.$table.searchForm.filter(item => item.alwaysDisplay)
+    },
+    canSearchCollapse() {
+      return (
+        this.$table.canSearchCollapse && this.alwaysDisplayContent.length > 0
+      )
+    },
+    isSearchCollapse() {
+      return this.$table.isSearchCollapse
+    },
+    currentForm() {
+      return this.isSearchCollapse ? 'alwaysDisplayForm' : 'mainForm'
+    }
+  },
+
+  watch: {
+    isSearchCollapse(collapse) {
+      this.updateForm(formValue)
+    }
+  },
+
+  mounted() {
+    unwatchMainForm = this.$refs.mainForm.$watch('value', val => {
+      formValue = Object.assign(formValue, val)
+    })
+    if (this.canSearchCollapse) {
+      unwatchAlwaysDisplayForm = this.$refs.alwaysDisplayForm.$watch(
+        'value',
+        val => {
+          formValue = Object.assign(formValue, val)
+        }
+      )
+    }
+  },
+
+  destroyed() {
+    unwatchMainForm()
+    if (this.canSearchCollapse) {
+      unwatchAlwaysDisplayForm()
+    }
+  },
+
+  methods: {
+    validate(fn) {
+      return this.$refs[this.currentForm].validate(fn)
+    },
+
+    resetFields() {
+      formValue = {}
+      this.$refs.mainForm.resetFields()
+      if (this.canSearchCollapse) {
+        this.$refs.alwaysDisplayForm.resetFields()
+      }
+    },
+
+    updateForm(value) {
+      formValue = Object.assign(formValue, value)
+      this.$refs.mainForm.updateForm(formValue)
+      if (this.canSearchCollapse) {
+        this.$refs.alwaysDisplayForm.updateForm(formValue)
+      }
+    },
+
+    getFormValue() {
+      return formValue
+    },
+
+    setOptions(id, options) {
+      this.$refs.mainForm.setOptions(id, options)
+      this.$refs.alwaysDisplayForm.setOptions(id, options)
+    }
+  }
+}
+</script>

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -95,10 +95,10 @@ export default {
       return this.$refs.normalForm.getFormValue()
     },
 
-    syncFormValue(activeForm, inactiveForm) {
+    syncFormValue(target, source) {
       if (this.hasUnCollapsibleForm) {
-        this.$refs[activeForm].updateForm(
-          this.$refs[inactiveForm].getFormValue()
+        this.$refs[target].updateForm(
+          this.$refs[source].getFormValue()
         )
       }
     },

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -54,15 +54,15 @@ export default {
     },
     currentForm() {
       return this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
-    },
-    inactiveForm() {
-      return !this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
     }
   },
 
   watch: {
     isSearchCollapse(collapse) {
-      this.updateFormValue(this.currentForm, this.inactiveForm)
+      this.updateFormValue(
+        this.currentForm,
+        !this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
+      )
     }
   },
 

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -15,7 +15,7 @@
     </el-form-renderer>
 
     <el-form-renderer
-      v-if="unCollapsibleForm"
+      v-if="hasUnCollapsibleForm"
       v-show="isSearchCollapse"
       ref="unCollapsibleForm"
       inline
@@ -51,7 +51,7 @@ export default {
     unCollapsibleContent() {
       return this.searchForm.filter(item => item.collapsible !== undefined || item.collapsible === false)
     },
-    unCollapsibleForm() {
+    hasUnCollapsibleForm() {
       return (
         this.canSearchCollapse && this.unCollapsibleContent.length > 0
       )
@@ -75,7 +75,7 @@ export default {
     unwatchNormalForm = this.$refs.normalForm.$watch('value', val => {
       formValue = Object.assign(formValue, val)
     })
-    if (this.canSearchCollapse) {
+    if (this.hasUnCollapsibleForm) {
       unwatchUnCollapsibleForm = this.$refs.unCollapsibleForm.$watch(
         'value',
         val => {
@@ -87,7 +87,7 @@ export default {
 
   beforeDestroy() {
     unwatchNormalForm()
-    if (this.canSearchCollapse) {
+    if (this.hasUnCollapsibleForm) {
       unwatchUnCollapsibleForm()
     }
   },
@@ -100,7 +100,7 @@ export default {
     resetFields() {
       formValue = {}
       this.$refs.normalForm.resetFields()
-      if (this.canSearchCollapse) {
+      if (this.hasUnCollapsibleForm) {
         this.$refs.unCollapsibleForm.resetFields()
       }
     },
@@ -108,7 +108,7 @@ export default {
     updateForm(value) {
       formValue = Object.assign(formValue, value)
       this.$refs.normalForm.updateForm(formValue)
-      if (this.canSearchCollapse) {
+      if (this.hasUnCollapsibleForm) {
         this.$refs.unCollapsibleForm.updateForm(formValue)
       }
     },
@@ -119,7 +119,7 @@ export default {
 
     setOptions(id, options) {
       this.$refs.normalForm.setOptions(id, options)
-      if (this.canSearchCollapse) {
+      if (this.hasUnCollapsibleForm) {
         this.$refs.unCollapsibleForm.setOptions(id, options)
       }
     }

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -28,10 +28,6 @@
 </template>
 
 <script>
-let formValue = {}
-let unwatchNormalForm
-let unwatchUnCollapsibleForm
-
 export default {
   name: 'SearchForm',
 
@@ -49,46 +45,24 @@ export default {
 
   computed: {
     unCollapsibleContent() {
-      return this.searchForm.filter(item => item.collapsible !== undefined || item.collapsible === false)
+      return this.searchForm.filter(
+        item => item.collapsible !== undefined || item.collapsible === false
+      )
     },
     hasUnCollapsibleForm() {
-      return (
-        this.canSearchCollapse && this.unCollapsibleContent.length > 0
-      )
+      return this.canSearchCollapse && this.unCollapsibleContent.length > 0
     },
     currentForm() {
       return this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
+    },
+    inactiveForm() {
+      return !this.isSearchCollapse ? 'unCollapsibleForm' : 'normalForm'
     }
   },
 
   watch: {
     isSearchCollapse(collapse) {
-      this.updateForm(formValue)
-    }
-  },
-
-  mounted() {
-    formValue = Object.assign(
-      {},
-      this.$refs.normalForm.getFormValue()
-    )
-    unwatchNormalForm = this.$refs.normalForm.$watch('value', val => {
-      formValue = Object.assign(formValue, val)
-    })
-    if (this.hasUnCollapsibleForm) {
-      unwatchUnCollapsibleForm = this.$refs.unCollapsibleForm.$watch(
-        'value',
-        val => {
-          formValue = Object.assign(formValue, val)
-        }
-      )
-    }
-  },
-
-  beforeDestroy() {
-    unwatchNormalForm()
-    if (this.hasUnCollapsibleForm) {
-      unwatchUnCollapsibleForm()
+      this.updateFormValue(this.currentForm, this.inactiveForm)
     }
   },
 
@@ -98,7 +72,6 @@ export default {
     },
 
     resetFields() {
-      formValue = {}
       this.$refs.normalForm.resetFields()
       if (this.hasUnCollapsibleForm) {
         this.$refs.unCollapsibleForm.resetFields()
@@ -106,15 +79,28 @@ export default {
     },
 
     updateForm(value) {
-      formValue = Object.assign(formValue, value)
-      this.$refs.normalForm.updateForm(formValue)
+      this.$refs.normalForm.updateForm(value)
       if (this.hasUnCollapsibleForm) {
-        this.$refs.unCollapsibleForm.updateForm(formValue)
+        this.$refs.unCollapsibleForm.updateForm(value)
       }
     },
 
     getFormValue() {
-      return formValue
+      if (this.hasUnCollapsibleForm) {
+        this.$refs.normalForm.updateForm(
+          this.$refs.unCollapsibleForm.getFormValue()
+        )
+      }
+
+      return this.$refs.normalForm.getFormValue()
+    },
+
+    updateFormValue(activeForm, inactiveForm) {
+      if (this.hasUnCollapsibleForm) {
+        this.$refs[activeForm].updateForm(
+          this.$refs[inactiveForm].getFormValue()
+        )
+      }
     },
 
     setOptions(id, options) {

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -8,18 +8,18 @@
       v-show="!isSearchCollapse"
       ref="normalForm"
       inline
-      :content="$table.searchForm"
+      :content="searchForm"
       @submit.native.prevent
     >
       <slot />
     </el-form-renderer>
 
     <el-form-renderer
-      v-if="canSearchCollapse"
+      v-if="unCollapsibleForm"
       v-show="isSearchCollapse"
       ref="alwaysDisplayForm"
       inline
-      :content="alwaysDisplayContent"
+      :content="unCollapsibleContent"
       @submit.native.prevent
     >
       <slot />
@@ -35,19 +35,26 @@ let unwatchAlwaysDisplayForm
 export default {
   name: 'SearchForm',
 
-  inject: ['$table'],
+  props: {
+    searchForm: {
+      type: Array
+    },
+    canSearchCollapse: {
+      type: Boolean
+    },
+    isSearchCollapse: {
+      type: Boolean
+    }
+  },
 
   computed: {
-    alwaysDisplayContent() {
-      return this.$table.searchForm.filter(item => item.alwaysDisplay)
+    unCollapsibleContent() {
+      return this.searchForm.filter(item => item.collapsible !== undefined || item.collapsible === false)
     },
-    canSearchCollapse() {
+    unCollapsibleForm() {
       return (
-        this.$table.canSearchCollapse && this.alwaysDisplayContent.length > 0
+        this.canSearchCollapse && this.unCollapsibleContent.length > 0
       )
-    },
-    isSearchCollapse() {
-      return this.$table.isSearchCollapse
     },
     currentForm() {
       return this.isSearchCollapse ? 'alwaysDisplayForm' : 'normalForm'

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -5,7 +5,13 @@
       <slot name="no-data"></slot>
     </template>
     <template v-else>
-      <search-form ref="searchForm" v-if="hasSearchForm">
+      <search-form
+        v-if="hasSearchForm"
+        ref="searchForm"
+        :search-form="searchForm"
+        :can-search-collapse="canSearchCollapse"
+        :is-search-collapse="isSearchCollapse"
+      >
         <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
         <slot name="search"></slot>
         <el-form-item>
@@ -266,12 +272,6 @@ export default {
     TextButton,
     TheDialog,
     SearchForm
-  },
-
-  provide() {
-    return {
-      $table: this
-    }
   },
 
   props: {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -5,18 +5,7 @@
       <slot name="no-data"></slot>
     </template>
     <template v-else>
-      <!-- @submit.native.prevent -->
-      <!-- 阻止表单提交的默认行为 -->
-      <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
-      <!--搜索字段-->
-      <el-form-renderer
-        v-if="hasSearchForm"
-        v-show="!isSearchCollapse"
-        inline
-        :content="searchForm"
-        ref="searchForm"
-        @submit.native.prevent
-      >
+      <search-form ref="searchForm" v-if="hasSearchForm">
         <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
         <slot name="search"></slot>
         <el-form-item>
@@ -30,7 +19,7 @@
           >
           <el-button @click="resetSearch" size="small">重置</el-button>
         </el-form-item>
-      </el-form-renderer>
+      </search-form>
 
       <el-form v-if="hasHeader">
         <el-form-item>
@@ -243,6 +232,7 @@ import _get from 'lodash.get'
 import SelfLoadingButton from './components/self-loading-button.vue'
 import TextButton from './components/text-button.vue'
 import TheDialog, {dialogModes} from './components/the-dialog.vue'
+import SearchForm from './components/search-form.vue'
 import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
 
@@ -274,8 +264,16 @@ export default {
   components: {
     SelfLoadingButton,
     TextButton,
-    TheDialog
+    TheDialog,
+    SearchForm
   },
+
+  provide() {
+    return {
+      $table: this
+    }
+  },
+
   props: {
     /**
      * 请求url, 如果为空, 则不会发送请求; 改变url, 则table会重新发送请求

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,9 +720,9 @@
     minimist "^1.2.0"
 
 "@femessage/el-form-renderer@^1.6.0":
-  version "1.11.1"
-  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.11.1.tgz#899bc46e469bd8187a54a1626c7f92dfeb95c37c"
-  integrity sha1-iZvEbkab2Bh6VKFibH+S3+uVw3w=
+  version "1.11.2"
+  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.11.2.tgz#bcd209fa3f9057de6463d91aa71b052219764eaa"
+  integrity sha1-vNIJ+j+QV95kY9kapxsFIhl2Tqo=
   dependencies:
     lodash.get "^4.4.2"
     lodash.set "^4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,9 +720,9 @@
     minimist "^1.2.0"
 
 "@femessage/el-form-renderer@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.6.0.tgz#43bbd94d3a21efe6b16564fdf6db7cfc2e646b11"
-  integrity sha1-Q7vZTToh7+axZWT99tt8/C5kaxE=
+  version "1.11.1"
+  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.11.1.tgz#899bc46e469bd8187a54a1626c7f92dfeb95c37c"
+  integrity sha1-iZvEbkab2Bh6VKFibH+S3+uVw3w=
   dependencies:
     lodash.get "^4.4.2"
     lodash.set "^4.3.2"


### PR DESCRIPTION
## Why

用户需求(当搜索项多并且部分重要的时候)

## Usage

当某表单项设置为不可折叠时,折叠与否总是可见.

```js
const content = [
  {
    collapsible: false
  }
]
```

## How

- 封装一个组件,他包含 2 个表单(1个是全部表单项 **{A}** ,另1个是只显示[总是可见]的表单项 **{B}** )
- 获取状态: `isSearchCollapse` ,开启折叠状态 `canSearchCollapse` 和表单项配置: `searchForm` 
- 如果没开启 canSearchCollapse 则不渲染(v-if) **B** 表单, 则保持原始行为
- return
- 赋值给表单
  - 默认表单项赋值给 **A** 表单
  - 筛选出[总是可见]的表单项赋值给 **B** 表单
- 根据 isSearchCollapse 切换实际显示的表单
- 根据 isSearchCollapse 的变动,来回赋值表单值, A->B, A<-B
  - 因为折叠后与否,用户都有可能变更表单输入的值, 确保他们的输入一致.

## Test

```console
$ jest --verbose
 PASS  test/query.test.js
  测试 stringify
    ✓ 基本功能 (9ms)
    ✓ 自定义 equal & delimiter (1ms)
  测试 parse
    ✓ 基本功能 (3ms)
    ✓ 自定义 equal & delimiter (1ms)
  测试 set
    ✓ 通过所有用例 (10ms)
    ✓ 多次set仍是幂等操作 (3ms)
    ✓ url已经有query时会被替换成新的 (4ms)
  测试 get
    ✓ 通过所有用例 (3ms)
  测试 clear
    ✓ 通过所有用例 (2ms)

 PASS  test/select-strategy.test.js
  测试 normal 模式
    ✓ onSelectionChange (6ms)
    ✓ toggleRowSelection (2ms)
    ✓ clearSelection (1ms)
  测试 persistSelection 模式
    ✓ onSelect (6ms)
    ✓ onSelectAll (9ms)
    ✓ toggleRowSelection (7ms)
    ✓ clearSelection (1ms)

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        5.424s
Ran all test suites.
```

## Docs

- search-collapse-always-display.md

![collapse](https://user-images.githubusercontent.com/53422750/63338490-79966480-c375-11e9-90a4-8bdcb7c424e6.gif)

## 其余注意点

- [ ] ~~如何处理插槽~~

## emm?

- el-form-renderer 级别的支持是**可能**最好的选择, `setStatus(id, 'hidden')`