### PR TITLE
fix: search-slot 在开启折叠下切换折叠, 插槽内容没有同步

### DIFF
--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -1,9 +1,5 @@
 <template>
   <div v-show="hasUnCollapsibleForm || !isSearchCollapse">
-    <!-- 搜索字段 -->
-    <!-- @submit.native.prevent -->
-    <!-- 阻止表单提交的默认行为 -->
-    <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
     <el-form-renderer
       class="inline"
       v-show="!isSearchCollapse"
@@ -21,6 +17,10 @@
       :content="unCollapsibleContent"
     />
 
+    <!-- 搜索字段 -->
+    <!-- @submit.native.prevent -->
+    <!-- 阻止表单提交的默认行为 -->
+    <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
     <el-form
       inline
       class="inline"

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -1,29 +1,33 @@
 <template>
-  <div>
+  <div v-show="hasUnCollapsibleForm || !isSearchCollapse">
     <!-- 搜索字段 -->
     <!-- @submit.native.prevent -->
     <!-- 阻止表单提交的默认行为 -->
     <!-- https://www.w3.org/MarkUp/html-spec/html-spec_8.html#SEC8.2 -->
     <el-form-renderer
+      class="inline"
       v-show="!isSearchCollapse"
       ref="normalForm"
       inline
       :content="searchForm"
-      @submit.native.prevent
-    >
-      <slot />
-    </el-form-renderer>
+    />
 
     <el-form-renderer
+      class="inline"
       v-if="hasUnCollapsibleForm"
       v-show="isSearchCollapse"
       ref="unCollapsibleForm"
       inline
       :content="unCollapsibleContent"
+    />
+
+    <el-form
+      inline
+      class="inline"
       @submit.native.prevent
     >
       <slot />
-    </el-form-renderer>
+    </el-form>
   </div>
 </template>
 
@@ -112,3 +116,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.inline {
+  display: inline;
+}
+</style>


### PR DESCRIPTION
## Why

使用search插槽折叠后,表单值没有同步的问题

## How

1. 新增一个表单el-form,用来存放插槽和按钮,即存在3个表单(A:默认完整表单)(B:不可折叠项表单)(C:search插槽以及查询重置按钮)
2. 移除A,B表单的slot,只是用C表单的slot
3. 3个表单设置样式为 display: inline

## Test

```html
<el-data-table v-bind="$data" ref="table">
  <input slot="search" />
</el-data-table>
```

### before

![search-slot](https://user-images.githubusercontent.com/53422750/63482679-56ca9400-c4cc-11e9-9a62-f3d2176c0311.gif)

### after

![search-slot-fixed](https://user-images.githubusercontent.com/53422750/63482716-8083bb00-c4cc-11e9-9d7a-c93bcd12a44a.gif)

