### PR TITLE
fix: 使用需要弹窗的功能并把 hasDialog 设置为 false 时, 将会报错

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -948,7 +948,7 @@ export default {
     checkHasDialog() {
       if (!this.hasDialog) {
         throw Error(
-          'ElDataTable: 当 hasNew 或 hasEdit 或 hasView 设置为 true 时， hasDialog 不能为 false'
+          'ElDataTable: 当 hasNew 或 hasEdit 或 hasView 设置为 true 时， hasDialog 不能设置为 false'
         )
       }
     },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -945,15 +945,25 @@ export default {
     },
     // 弹窗相关
     // 除非树形结构在操作列点击新增, 否则 row 都是 undefined
+    checkHasDialog() {
+      if (!this.hasDialog) {
+        throw Error(
+          'ElDataTable: 当 hasNew 或 hasEdit 或 hasView 设置为 true 时， hasDialog 不能为 false'
+        )
+      }
+    },
     onDefaultNew(row = {}) {
+      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.new)
     },
     onDefaultView(row) {
+      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.view, row)
     },
     onDefaultEdit(row) {
+      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.edit, row)
     },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -566,13 +566,6 @@ export default {
       }
     },
     /**
-     * 是否有弹窗, 用于不需要弹窗时想减少DOM渲染的场景
-     */
-    hasDialog: {
-      type: Boolean,
-      default: true
-    },
-    /**
      * 新增弹窗的标题，默认为newText的值
      */
     dialogNewTitle: {
@@ -724,6 +717,9 @@ export default {
         this.headerButtons.length ||
         this.canSearchCollapse
       )
+    },
+    hasDialog() {
+      return this.hasNew || this.hasEdit || this.hasView
     },
     _extraBody() {
       return this.extraBody || this.extraParams || {}
@@ -945,25 +941,15 @@ export default {
     },
     // 弹窗相关
     // 除非树形结构在操作列点击新增, 否则 row 都是 undefined
-    checkHasDialog() {
-      if (!this.hasDialog) {
-        throw Error(
-          'ElDataTable: 当 hasNew 或 hasEdit 或 hasView 设置为 true 时， hasDialog 不能设置为 false'
-        )
-      }
-    },
     onDefaultNew(row = {}) {
-      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.new)
     },
     onDefaultView(row) {
-      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.view, row)
     },
     onDefaultEdit(row) {
-      this.checkHasDialog()
       this.row = row
       this.$refs.dialog.show(dialogModes.edit, row)
     },


### PR DESCRIPTION
close #210

## Why
点击查看或编辑或新增按钮时，如果用户是把 hasDialog 设置为 false，将会报错

## How
1. 删除 hasDialog prop
2. 改用 computed 判断是否渲染弹窗

## Docs
文档中 hasDialog 参数被删除