### PR TITLE
feat: 搜索表单支持定位插槽

### DIFF
--- a/docs/slot-search.md
+++ b/docs/slot-search.md
@@ -8,8 +8,8 @@ search插槽
       <el-rate v-model="extraQuery.rate" style="display: inline-block"></el-rate>
     </template>
     <template slot="search:q">
-      <el-tag slot="label">slot=search:q</el-tag>
       <el-form-item>
+        <el-tag slot="label">slot=search:q</el-tag>
         <el-input></el-input>
       </el-form-item>
     </template>

--- a/docs/slot-search.md
+++ b/docs/slot-search.md
@@ -10,9 +10,8 @@ search插槽
 
     <!-- 定位插入 `q` 的前面 -->
     <template slot="search:q">
-      <el-form-item>
-        <el-tag slot="label">slot=search:q</el-tag>
-        <el-input value="定位插入在 `q` 的前面"></el-input>
+      <el-form-item label="我是`search:q`插槽">
+        <el-input value="在表单 id 为 `q` 的前面"></el-input>
       </el-form-item>
     </template>
   </el-data-table>

--- a/docs/slot-search.md
+++ b/docs/slot-search.md
@@ -7,10 +7,12 @@ search插槽
       <el-tag>slot=search</el-tag>
       <el-rate v-model="extraQuery.rate" style="display: inline-block"></el-rate>
     </template>
+
+    <!-- 定位插入 `q` 的前面 -->
     <template slot="search:q">
       <el-form-item>
         <el-tag slot="label">slot=search:q</el-tag>
-        <el-input></el-input>
+        <el-input value="定位插入在 `q` 的前面"></el-input>
       </el-form-item>
     </template>
   </el-data-table>

--- a/docs/slot-search.md
+++ b/docs/slot-search.md
@@ -2,12 +2,16 @@ search插槽
 
 ```vue
 <template>
-  <el-data-table
-    v-bind="$data"
-  >
+  <el-data-table v-bind="$data">
     <template slot="search">
       <el-tag>slot=search</el-tag>
       <el-rate v-model="extraQuery.rate" style="display: inline-block"></el-rate>
+    </template>
+    <template slot="search:q">
+      <el-tag slot="label">slot=search:q</el-tag>
+      <el-form-item>
+        <el-input></el-input>
+      </el-form-item>
     </template>
   </el-data-table>
 </template>

--- a/docs/slot-search.md
+++ b/docs/slot-search.md
@@ -8,7 +8,6 @@ search插槽
       <el-rate v-model="extraQuery.rate" style="display: inline-block"></el-rate>
     </template>
 
-    <!-- 定位插入 `q` 的前面 -->
     <template slot="search:q">
       <el-form-item label="我是`search:q`插槽">
         <el-input value="在表单 id 为 `q` 的前面"></el-input>

--- a/src/components/search-form.vue
+++ b/src/components/search-form.vue
@@ -11,6 +11,11 @@
       :content="searchForm"
       @submit.native.prevent
     >
+      <slot
+        v-for="slot in locatedSlotKeys"
+        :name="slot"
+        :slot="replaceToId(slot)"
+      />
       <slot />
     </el-form-renderer>
 
@@ -22,6 +27,11 @@
       :content="unCollapsibleContent"
       @submit.native.prevent
     >
+      <slot
+        v-for="slot in locatedSlotKeys"
+        :name="slot"
+        :slot="replaceToId(slot)"
+      />
       <slot />
     </el-form-renderer>
   </div>
@@ -40,6 +50,9 @@ export default {
     },
     isSearchCollapse: {
       type: Boolean
+    },
+    locatedSlotKeys: {
+      type: Array
     }
   },
 
@@ -108,6 +121,10 @@ export default {
       if (this.hasUnCollapsibleForm) {
         this.$refs.unCollapsibleForm.setOptions(id, options)
       }
+    },
+
+    replaceToId(key) {
+      return key.replace('search:', 'id:')
     }
   }
 }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -11,8 +11,14 @@
         :search-form="searchForm"
         :can-search-collapse="canSearchCollapse"
         :is-search-collapse="isSearchCollapse"
+        :located-slot-keys="searchLocatedSlotKeys"
       >
         <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
+        <slot
+          v-for="slot in searchLocatedSlotKeys"
+          :name="slot"
+          :slot="slot"
+        />
         <slot name="search"></slot>
         <el-form-item>
           <!--https://github.com/ElemeFE/element/pull/5920-->
@@ -245,6 +251,7 @@ import TheDialog, {dialogModes} from './components/the-dialog.vue'
 import SearchForm from './components/search-form.vue'
 import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
+import getLocatedSlotKeys from './utils/extract-keys'
 
 // 默认返回的数据格式如下
 //          {
@@ -732,6 +739,9 @@ export default {
     },
     selectStrategy() {
       return getSelectStrategy(this)
+    },
+    searchLocatedSlotKeys() {
+      return getLocatedSlotKeys(this.$slots, 'search:')
     }
   },
   watch: {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -13,12 +13,12 @@
         :is-search-collapse="isSearchCollapse"
         :located-slot-keys="searchLocatedSlotKeys"
       >
-        <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
         <slot
           v-for="slot in searchLocatedSlotKeys"
           :name="slot"
           :slot="slot"
         />
+        <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
         <slot name="search"></slot>
         <el-form-item>
           <!--https://github.com/ElemeFE/element/pull/5920-->

--- a/src/utils/extract-keys.js
+++ b/src/utils/extract-keys.js
@@ -1,0 +1,4 @@
+export default ($slots, name) => {
+  const keys = Object.keys($slots)
+  return keys.filter(key => key.indexOf(name) > -1)
+}

--- a/test/extract-keys.test.js
+++ b/test/extract-keys.test.js
@@ -1,6 +1,6 @@
 import extractKeys from '../src/utils/extract-keys'
 
-const store = {
+const slotsObj = {
   search: '',
   'search:name': '',
   'search:cute': ''
@@ -8,18 +8,18 @@ const store = {
 
 test('提取指定 key `search:`', () => {
   expect(
-    extractKeys(store, 'search:')
+    extractKeys(slotsObj, 'search:')
   ).toEqual(['search:name', 'search:cute'])
 })
 
 test('提取符合全部 key `search`', () => {
   expect(
-    extractKeys(store, 'search')
+    extractKeys(slotsObj, 'search')
   ).toEqual(['search', 'search:name', 'search:cute'])
 })
 
 test('提取不存在的 key', () => {
   expect(
-    extractKeys(store, 'form')
+    extractKeys(slotsObj, 'form')
   ).toEqual([])
 })

--- a/test/extract-keys.test.js
+++ b/test/extract-keys.test.js
@@ -1,0 +1,25 @@
+import extractKeys from '../src/utils/extract-keys'
+
+const store = {
+  search: '',
+  'search:name': '',
+  'search:cute': ''
+}
+
+test('提取指定 key `search:`', () => {
+  expect(
+    extractKeys(store, 'search:')
+  ).toEqual(['search:name', 'search:cute'])
+})
+
+test('提取符合全部 key `search`', () => {
+  expect(
+    extractKeys(store, 'search')
+  ).toEqual(['search', 'search:name', 'search:cute'])
+})
+
+test('提取不存在的 key', () => {
+  expect(
+    extractKeys(store, 'form')
+  ).toEqual([])
+})


### PR DESCRIPTION
## Why

用户需求

## How

![image](https://user-images.githubusercontent.com/53422750/64417128-1b82b480-d0cb-11e9-8ce1-35fb08715319.png)

## Example

```html
<el-data-table>
  <!-- 将会定位插入在搜索表单 id 为 `gender` 的前面 -->
  <el-form-item slot="search:gender" label="Oh My Slot">
    <el-input value="slot=search:gender" />
  </el-form-item>
</el-data-table>
```

## Test

```console
$ jest --verbose test/extract-keys.test.js
 PASS  test/extract-keys.test.js
  ✓ 提取指定 key `search:` (5ms)
  ✓ 提取符合全部 key `search` (1ms)
  ✓ 提取不存在的 key

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.109s
```

## Docs

- `slot-search.md` 添加一个定位插槽的输入框 `slot=search:q`

![image](https://user-images.githubusercontent.com/53422750/64599895-d1f8d900-d3ec-11e9-8dc2-6635b24fa6f3.png)

```diff
<template>
  <el-data-table v-bind="$data">
    <template slot="search">
      <el-tag>slot=search</el-tag>
      <el-rate v-model="extraQuery.rate" style="display: inline-block"></el-rate>
    </template>
+   <template slot="search:q">
+     <el-form-item>
+       <el-tag slot="label">slot=search:q</el-tag>
+       <el-input></el-input>
+     </el-form-item>
+   </template>
  </el-data-table>
</template>
```

