### PR TITLE
refactor: remove hasDialog related code

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -218,7 +218,6 @@
       ></el-pagination>
 
       <the-dialog
-        v-if="hasDialog"
         :newTitle="dialogNewTitle"
         :editTitle="dialogEditTitle"
         :viewTitle="dialogViewTitle"
@@ -720,9 +719,6 @@ export default {
         this.headerButtons.length ||
         this.canSearchCollapse
       )
-    },
-    hasDialog() {
-      return this.hasNew || this.hasEdit || this.hasView
     },
     _extraBody() {
       return this.extraBody || this.extraParams || {}


### PR DESCRIPTION
## Why

re #214 

## How

移除 `hasDialog` 相关的代码

## Test

```console
$ jest --verbose
 PASS  test/query.test.js
  测试 stringify
    ✓ 基本功能 (9ms)
    ✓ 自定义 equal & delimiter (1ms)
  测试 parse
    ✓ 基本功能 (2ms)
    ✓ 自定义 equal & delimiter (7ms)
  测试 set
    ✓ 通过所有用例 (5ms)
    ✓ 多次set仍是幂等操作 (3ms)
    ✓ url已经有query时会被替换成新的 (2ms)
  测试 get
    ✓ 通过所有用例 (3ms)
  测试 clear
    ✓ 通过所有用例 (2ms)

 PASS  test/select-strategy.test.js
  测试 normal 模式
    ✓ onSelectionChange (7ms)
    ✓ toggleRowSelection (2ms)
    ✓ clearSelection (1ms)
  测试 persistSelection 模式
    ✓ onSelect (3ms)
    ✓ onSelectAll (1ms)
    ✓ toggleRowSelection (2ms)
    ✓ clearSelection

Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        6.335s
Ran all test suites.
```

