### PR TITLE
fix: 奇怪的重置行为

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -13,11 +13,7 @@
         :is-search-collapse="isSearchCollapse"
         :located-slot-keys="searchLocatedSlotKeys"
       >
-        <slot
-          v-for="slot in searchLocatedSlotKeys"
-          :name="slot"
-          :slot="slot"
-        />
+        <slot v-for="slot in searchLocatedSlotKeys" :name="slot" :slot="slot" />
         <!--@slot 额外的搜索内容, 当searchForm不满足需求时可以使用-->
         <slot name="search"></slot>
         <el-form-item>
@@ -905,10 +901,6 @@ export default {
         history.replaceState(history.state, '', newUrl)
       }
 
-      this.$nextTick(() => {
-        this.getList()
-      })
-
       /**
        * 按下重置按钮后触发
        */
@@ -916,6 +908,10 @@ export default {
 
       this.$emit('update:customQuery', JSON.parse(this.initExtraQuery))
       this.$emit('update:extraQuery', JSON.parse(this.initExtraQuery))
+
+      this.$nextTick(() => {
+        this.getList()
+      })
     },
     handleSizeChange(val) {
       if (this.size === val) return


### PR DESCRIPTION
## Why

有 bug 啦. 当使用 extraQuery 的时候需要点击2次[重置]才能彻底清除 url 中的 extra 参数.

## How

- 挪动 resetSearch 中 getList 位置到后面.

## Test

before

![image](https://user-images.githubusercontent.com/53422750/64764724-4cecfb80-d575-11e9-8620-f0a7145e9a9b.png)

after

![image](https://user-images.githubusercontent.com/53422750/64764735-54aca000-d575-11e9-9471-baef54658f63.png)

