### PR TITLE
feat: 支持统一定制按钮大小

### DIFF
--- a/docs/guide-contributing-correctly.md
+++ b/docs/guide-contributing-correctly.md
@@ -1,0 +1,13 @@
+# 正确地为组件贡献
+
+## 关于按钮大小
+
+我们使用 `prop.buttonSize` 统一控制按钮大小.
+
+因此, 在开发或贡献的时候有需要添加新的按钮的情况, 需要使用 `buttonSize` 来控制, 使得风格统一.
+
+例如这样写:
+
+```html
+<el-button :size="buttonSize">新增的按钮</el-button>
+```

--- a/src/components/the-dialog.vue
+++ b/src/components/the-dialog.vue
@@ -18,12 +18,12 @@
     </el-form-renderer>
 
     <div slot="footer" v-show="!isView">
-      <el-button @click="visible = false" size="small">取 消</el-button>
+      <el-button @click="visible = false" :size="buttonSize">取 消</el-button>
       <el-button
         type="primary"
         @click="confirm"
         :loading="confirmLoading"
-        size="small"
+        :size="buttonSize"
         >确 定</el-button
       >
     </div>
@@ -62,7 +62,8 @@ export default {
     dialogAttrs: {
       type: Object,
       required: true
-    }
+    },
+    buttonSize: String
   },
   data() {
     return {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -172,7 +172,7 @@
             <self-loading-button
               v-if="isTree && hasNew"
               type="primary"
-              :size="operationButtonType === 'text' ? '' : 'small'"
+              :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"
               @click="onDefaultNew(scope.row)"
             >
@@ -181,7 +181,7 @@
             <self-loading-button
               v-if="hasEdit"
               type="primary"
-              :size="operationButtonType === 'text' ? '' : 'small'"
+              :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"
               @click="onDefaultEdit(scope.row)"
             >
@@ -190,7 +190,7 @@
             <self-loading-button
               v-if="hasView"
               type="primary"
-              :size="operationButtonType === 'text' ? '' : 'small'"
+              :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"
               @click="onDefaultView(scope.row)"
             >
@@ -213,7 +213,7 @@
             <self-loading-button
               v-if="!hasSelect && hasDelete && canDelete(scope.row)"
               type="danger"
-              :size="operationButtonType === 'text' ? '' : 'small'"
+              :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"
               @click="onDefaultDelete(scope.row)"
             >

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -22,10 +22,10 @@
             native-type="submit"
             type="primary"
             @click="search"
-            size="small"
+            :size="buttonSize"
             >查询</el-button
           >
-          <el-button @click="resetSearch" size="small">重置</el-button>
+          <el-button @click="resetSearch" :size="buttonSize">重置</el-button>
         </el-form-item>
       </search-form>
 
@@ -34,7 +34,7 @@
           <el-button
             v-if="hasNew"
             type="primary"
-            size="small"
+            :size="buttonSize"
             @click="onDefaultNew"
             >{{ newText }}</el-button
           >
@@ -45,16 +45,16 @@
             :click="btn.atClick"
             :params="selected"
             :callback="getList"
+            :size="buttonSize"
             v-bind="btn"
             :key="i"
-            size="small"
           >
             {{ typeof btn.text === 'function' ? btn.text(selected) : btn.text }}
           </self-loading-button>
           <el-button
             v-if="hasSelect && hasDelete"
             type="danger"
-            size="small"
+            :size="buttonSize"
             @click="onDefaultDelete($event)"
             :disabled="
               single
@@ -66,7 +66,7 @@
           <el-button
             v-if="canSearchCollapse"
             type="default"
-            size="small"
+            :size="buttonSize"
             :icon="`el-icon-arrow-${isSearchCollapse ? 'down' : 'up'}`"
             @click="isSearchCollapse = !isSearchCollapse"
             >{{ isSearchCollapse ? '展开' : '折叠' }}搜索</el-button
@@ -226,6 +226,7 @@
         :form="form"
         :formAttrs="formAttrs"
         :dialogAttrs="dialogAttrs"
+        :buttonSize="buttonSize"
         ref="dialog"
         @confirm="onConfirm"
       >
@@ -682,6 +683,14 @@ export default {
     saveQuery: {
       type: Boolean,
       default: true
+    },
+    /**
+     * 设置 `按钮` 大小
+     * @see https://element.eleme.cn/#/zh-CN/component/button#bu-tong-chi-cun
+     */
+    buttonSize: {
+      type: String,
+      default: 'small'
     }
   },
   data() {


### PR DESCRIPTION
close #216

## Why

- 用户需求: 为了让表格按钮跟项目统一对齐,与整体风格保持一致.

## How

1. 提供 `prop.buttonSize`
2. 应用于所有组件本身自带的 button, 包括搜索区域,头部按钮区域,对话框区域和操作栏按钮(文本按钮不会影响)
3. 保持默认为 `small`, 其余选项跟 el-button.size 保持一致

## Test

<!--

![button-size](https://user-images.githubusercontent.com/53422750/65590307-24292500-dfbd-11e9-92a0-9deb77f3b598.gif)

-->

![button-size2](https://user-images.githubusercontent.com/53422750/65746642-eef21380-e131-11e9-9639-0520eac09a0f.gif)

## Docs

- docs/guide-contributing-correctly.md
