### PR TITLE
feat: 支持切换操作栏按钮风格

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -169,37 +169,56 @@
           v-bind="operationAttrs"
         >
           <template slot-scope="scope">
-            <text-button
+            <self-loading-button
               v-if="isTree && hasNew"
+              type="primary"
+              :size="columnButtonType === 'text' ? '' : 'small'"
+              :is-text="columnButtonType === 'text'"
               @click="onDefaultNew(scope.row)"
-              >{{ newText }}</text-button
             >
-            <text-button v-if="hasEdit" @click="onDefaultEdit(scope.row)">{{
-              editText
-            }}</text-button>
-            <text-button v-if="hasView" @click="onDefaultView(scope.row)">{{
-              viewText
-            }}</text-button>
+              {{ newText }}
+            </self-loading-button>
+            <self-loading-button
+              v-if="hasEdit"
+              type="primary"
+              :size="columnButtonType === 'text' ? '' : 'small'"
+              :is-text="columnButtonType === 'text'"
+              @click="onDefaultEdit(scope.row)"
+            >
+              {{ editText }}
+            </self-loading-button>
+            <self-loading-button
+              v-if="hasView"
+              type="primary"
+              :size="columnButtonType === 'text' ? '' : 'small'"
+              :is-text="columnButtonType === 'text'"
+              @click="onDefaultView(scope.row)"
+            >
+              {{ viewText }}
+            </self-loading-button>
             <self-loading-button
               v-for="(btn, i) in extraButtons"
               v-if="'show' in btn ? btn.show(scope.row) : true"
+              :is-text="columnButtonType === 'text'"
               v-bind="btn"
               :click="btn.atClick"
               :params="scope.row"
               :callback="getList"
               :key="i"
-              is-text
             >
               {{
                 typeof btn.text === 'function' ? btn.text(scope.row) : btn.text
               }}
             </self-loading-button>
-            <text-button
+            <self-loading-button
               v-if="!hasSelect && hasDelete && canDelete(scope.row)"
               type="danger"
+              :size="columnButtonType === 'text' ? '' : 'small'"
+              :is-text="columnButtonType === 'text'"
               @click="onDefaultDelete(scope.row)"
-              >删除</text-button
             >
+              删除
+            </self-loading-button>
           </template>
         </el-table-column>
 
@@ -682,6 +701,14 @@ export default {
     saveQuery: {
       type: Boolean,
       default: true
+    },
+    /**
+     * 操作栏按钮风格
+     * `text` 为文本按钮, `button` 为普通按钮
+     */
+    columnButtonType: {
+      type: String,
+      default: 'text'
     }
   },
   data() {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -172,8 +172,8 @@
             <self-loading-button
               v-if="isTree && hasNew"
               type="primary"
-              :size="columnButtonType === 'text' ? '' : 'small'"
-              :is-text="columnButtonType === 'text'"
+              :size="operationButtonType === 'text' ? '' : 'small'"
+              :is-text="operationButtonType === 'text'"
               @click="onDefaultNew(scope.row)"
             >
               {{ newText }}
@@ -181,8 +181,8 @@
             <self-loading-button
               v-if="hasEdit"
               type="primary"
-              :size="columnButtonType === 'text' ? '' : 'small'"
-              :is-text="columnButtonType === 'text'"
+              :size="operationButtonType === 'text' ? '' : 'small'"
+              :is-text="operationButtonType === 'text'"
               @click="onDefaultEdit(scope.row)"
             >
               {{ editText }}
@@ -190,8 +190,8 @@
             <self-loading-button
               v-if="hasView"
               type="primary"
-              :size="columnButtonType === 'text' ? '' : 'small'"
-              :is-text="columnButtonType === 'text'"
+              :size="operationButtonType === 'text' ? '' : 'small'"
+              :is-text="operationButtonType === 'text'"
               @click="onDefaultView(scope.row)"
             >
               {{ viewText }}
@@ -199,7 +199,7 @@
             <self-loading-button
               v-for="(btn, i) in extraButtons"
               v-if="'show' in btn ? btn.show(scope.row) : true"
-              :is-text="columnButtonType === 'text'"
+              :is-text="operationButtonType === 'text'"
               v-bind="btn"
               :click="btn.atClick"
               :params="scope.row"
@@ -213,8 +213,8 @@
             <self-loading-button
               v-if="!hasSelect && hasDelete && canDelete(scope.row)"
               type="danger"
-              :size="columnButtonType === 'text' ? '' : 'small'"
-              :is-text="columnButtonType === 'text'"
+              :size="operationButtonType === 'text' ? '' : 'small'"
+              :is-text="operationButtonType === 'text'"
               @click="onDefaultDelete(scope.row)"
             >
               删除
@@ -704,7 +704,7 @@ export default {
      * 操作栏按钮风格
      * `text` 为文本按钮, `button` 为普通按钮
      */
-    columnButtonType: {
+    operationButtonType: {
       type: String,
       default: 'text'
     }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -260,7 +260,6 @@
 <script>
 import _get from 'lodash.get'
 import SelfLoadingButton from './components/self-loading-button.vue'
-import TextButton from './components/text-button.vue'
 import TheDialog, {dialogModes} from './components/the-dialog.vue'
 import SearchForm from './components/search-form.vue'
 import * as queryUtil from './utils/query'
@@ -294,7 +293,6 @@ export default {
   name: 'ElDataTable',
   components: {
     SelfLoadingButton,
-    TextButton,
     TheDialog,
     SearchForm
   },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -701,7 +701,7 @@ export default {
       default: true
     },
     /**
-     * 操作栏按钮风格
+     * 操作栏按钮类型
      * `text` 为文本按钮, `button` 为普通按钮
      */
     operationButtonType: {


### PR DESCRIPTION
## Why

- 项目需求, 期望统一所有按钮风格!

## How

1. 提供 `prop: operationButtonType`
1. 默认保持为 `text` 风格, 可切换至 `button` 风格
1. 利用 `self-loading-button` 本身已有的 `prop: isText` 来切换按钮风格
1. 去掉主文件注册的 `text-button` 组件
1. 其余保持默认

## Little Show Case

![button-type](https://user-images.githubusercontent.com/53422750/65668166-c6a3df80-e073-11e9-9c30-245615fa0810.gif)
