### PR TITLE
feat(searchImmediately): 支持搜索表单项变更时自动搜索

### DIFF
--- a/src/el-data-table.md
+++ b/src/el-data-table.md
@@ -14,3 +14,16 @@ const content = [
   }
 ]
 ```
+
+当开启 `canSearchCollapse` 折叠表单的时候, 可以设置特定表单项不可折叠(无论折叠与否, 始终显示).
+
+```diff
+const content = [
+  {
+    id: 'name',
+    type: 'input',
+    label: 'name',
++   collapsible: false
+  }
+]
+```

--- a/src/el-data-table.md
+++ b/src/el-data-table.md
@@ -2,7 +2,7 @@
 
 ### searchForm
 
-出了原有的 el-form-renderer 的表单项配置, 每个表单项还可以添加如下配置, 以达到表单项变更时, 立即获取新的表格数据.
+除了原有的 el-form-renderer 的表单项配置, 每个表单项还可以添加如下配置, 以达到表单项变更时, 立即获取新的表格数据.
 
 ```diff
 const content = [

--- a/src/el-data-table.md
+++ b/src/el-data-table.md
@@ -1,0 +1,16 @@
+## Extra feature
+
+### searchForm
+
+出了原有的 el-form-renderer 的表单项配置, 每个表单项还可以添加如下配置, 以达到表单项变更时, 立即获取新的表格数据.
+
+```diff
+const content = [
+  {
+    id: 'name',
+    type: 'input',
+    label: 'name',
++   searchImmedialtely: true
+  }
+]
+```

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -720,7 +720,7 @@ export default {
     },
     /**
      * 搜索表单项变更时立即搜索
-     * `input` 和 自定义组件不会触发
+     * `input` 不会触发
      */
     searchImmediately: {
       type: Boolean,

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -8,7 +8,7 @@
       <search-form
         v-if="hasSearchForm"
         ref="searchForm"
-        :search-form="searchForm"
+        :search-form="_searchForm"
         :can-search-collapse="canSearchCollapse"
         :is-search-collapse="isSearchCollapse"
         :located-slot-keys="searchLocatedSlotKeys"
@@ -266,6 +266,7 @@ import SearchForm from './components/search-form.vue'
 import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
 import getLocatedSlotKeys from './utils/extract-keys'
+import transformSearchImmediatelyItem from './utils/search-immediately-item'
 
 // 默认返回的数据格式如下
 //          {
@@ -716,6 +717,14 @@ export default {
     buttonSize: {
       type: String,
       default: 'small'
+    },
+    /**
+     * 搜索表单项变更时立即搜索
+     * `input` 和 自定义组件不会触发
+     */
+    searchImmediately: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -768,6 +777,13 @@ export default {
     },
     searchLocatedSlotKeys() {
       return getLocatedSlotKeys(this.$slots, 'search:')
+    },
+    _searchForm() {
+      if (this.searchImmediately) {
+        return transformSearchImmediatelyItem(this.searchForm, this)
+      }
+
+      return this.searchForm
     }
   },
   watch: {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -717,14 +717,6 @@ export default {
     buttonSize: {
       type: String,
       default: 'small'
-    },
-    /**
-     * 搜索表单项变更时立即搜索
-     * `input` 不会触发
-     */
-    searchImmediately: {
-      type: Boolean,
-      default: false
     }
   },
   data() {
@@ -779,11 +771,7 @@ export default {
       return getLocatedSlotKeys(this.$slots, 'search:')
     },
     _searchForm() {
-      if (this.searchImmediately) {
-        return transformSearchImmediatelyItem(this.searchForm, this)
-      }
-
-      return this.searchForm
+      return transformSearchImmediatelyItem(this.searchForm, this)
     }
   },
   watch: {

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,10 @@
 // Import vue component
 import component from './el-data-table.vue'
 
-// install function executed by Vue.use()
-export function install(Vue) {
-  if (install.installed) return
-  install.installed = true
-  Vue.component('ElDataTable', component)
-}
-
-// Create module definition for Vue.use()
-const plugin = {
-  install
+// `Vue.use` automatically prevents you from using the same plugin more than once,
+// so calling it multiple times on the same plugin will install the plugin only once
+component.install = Vue => {
+  Vue.component(component.name, component)
 }
 
 // To auto-install when vue is found
@@ -21,7 +15,7 @@ if (typeof window !== 'undefined') {
   GlobalVue = global.Vue
 }
 if (GlobalVue) {
-  GlobalVue.use(plugin)
+  GlobalVue.use(component)
 }
 
 // To allow use as module (npm/webpack/etc.) export component

--- a/src/utils/search-immediately-item.js
+++ b/src/utils/search-immediately-item.js
@@ -1,6 +1,6 @@
 export default function(content, vm) {
   return content.map(item => {
-    const onInput = item.on && item.on.input
+    const origOnInput = item.on && item.on.input
 
     if (item.component || item.type === 'input') {
       return item
@@ -9,8 +9,8 @@ export default function(content, vm) {
     return Object.assign(item, {
       on: Object.assign({}, item.on, {
         input: (...args) => {
-          if (typeof onInput === 'function') {
-            onInput.call(item, ...args)
+          if (typeof origOnInput === 'function') {
+            origOnInput.call(item, ...args)
 
             vm.search()
           }

--- a/src/utils/search-immediately-item.js
+++ b/src/utils/search-immediately-item.js
@@ -2,7 +2,7 @@ export default function(content, vm) {
   return content.map(item => {
     const origOnInput = item.on && item.on.input
 
-    if (item.component || item.type === 'input') {
+    if (item.type === 'input') {
       return item
     }
 

--- a/src/utils/search-immediately-item.js
+++ b/src/utils/search-immediately-item.js
@@ -1,0 +1,21 @@
+export default function(content, vm) {
+  return content.map(item => {
+    const onInput = item.on && item.on.input
+
+    if (item.component || item.type === 'input') {
+      return item
+    }
+
+    return Object.assign(item, {
+      on: Object.assign({}, item.on, {
+        input: (...args) => {
+          if (typeof onInput === 'function') {
+            onInput.call(item, ...args)
+
+            vm.search()
+          }
+        }
+      })
+    })
+  })
+}

--- a/src/utils/search-immediately-item.js
+++ b/src/utils/search-immediately-item.js
@@ -2,19 +2,19 @@ export default function(content, vm) {
   return content.map(item => {
     const origOnInput = item.on && item.on.input
 
-    if (item.type === 'input') {
-      return item
+    if (item.searchImmediately) {
+      return Object.assign(item, {
+        on: Object.assign({}, item.on, {
+          input: (...args) => {
+            if (typeof origOnInput === 'function') {
+              origOnInput.call(item, ...args)
+            }
+            vm.search()
+          }
+        })
+      })
     }
 
-    return Object.assign(item, {
-      on: Object.assign({}, item.on, {
-        input: (...args) => {
-          if (typeof origOnInput === 'function') {
-            origOnInput.call(item, ...args)
-          }
-          vm.search()
-        }
-      })
-    })
+    return item
   })
 }

--- a/src/utils/search-immediately-item.js
+++ b/src/utils/search-immediately-item.js
@@ -11,9 +11,8 @@ export default function(content, vm) {
         input: (...args) => {
           if (typeof origOnInput === 'function') {
             origOnInput.call(item, ...args)
-
-            vm.search()
           }
+          vm.search()
         }
       })
     })


### PR DESCRIPTION
## Why

- 项目需求, 项目列表庞大的时候, 自动搜索会省心一点点.

## Inspiration

- 既然无法保证 component 实际上是什么, 各种 type 与 component 来回牵扯情况, 使用一种最保证的方法去实现, 即使需要多写点代码.
  - type: 'input' <=> component: 实际上是 'input'
  - type: 'select' <=> component: 实际上是 'select'
  - ...

## How

1. 提前处理一遍 searchForm 配置
2. 当 这个表单项 存在 `searchImmediately: true` 的时候, 值表更时触发搜索行为.

## Test

### 搜索表单立即搜索

![table-search-immediately](https://user-images.githubusercontent.com/53422750/66563026-78243400-eb8f-11e9-9249-67a22f4942e3.gif)

### 折叠的搜索表单是否会触发立马搜索

![table-search-immediately2](https://user-images.githubusercontent.com/53422750/66563043-7f4b4200-eb8f-11e9-8cbb-c82e0226c0b5.gif)

### 测试代码

```diff
{
  type: 'select',
  id: 'select',
  label: 'select',
+ searchImmediately: true,
  options: [
    {
      value: 1
    },
    {
      value: 2
    },
  ]
},
```

## Docs

- src/el-data-table.md 补充特有特性说明

## Tips

### 偷懒小贴士:

如果一次性为大部分表单项添加 `searchImmediately: true`:

```js
const formContent = content.map(item => {
  return Object.assign(item, {
    searchImmediately: true
  })
})
```