### PR TITLE
fix: 修复树形表数据无法直接stringify的问题

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1108,7 +1108,10 @@ export default {
         this.$set(record, '_level', _level)
         // 如果有父元素
         if (parent) {
-          this.$set(record, 'parent', parent)
+          Object.defineProperty(record, 'parent', {
+            value: parent,
+            enumerable: false
+          })
         }
         tmp.push(record)
 
@@ -1124,11 +1127,11 @@ export default {
       })
       return tmp
     },
-    showRow(row) {
-      const show = row.row.parent
-        ? row.row.parent._expanded && row.row.parent._show
+    showRow({row}) {
+      const show = row.parent
+        ? row.parent._expanded && row.parent._show
         : true
-      row.row._show = show
+      row._show = show
       return show ? 'row-show' : 'row-hide'
     },
     // 切换下级是否展开


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why
issue #234

## How
该问题是由于树形表给 child row 增加了 `parent` 属性引用了 parent row，到时调用 `JSON.stringify` 时报 `Uncaught TypeError: Converting circular structure to JSON` 的错误。

树形表通过 `$set` 的方式给 child row 增加 `parent` 属性，`parent` 目前主要是用于控制改行的 `row-show` 和 `row-hide` 类切换（以增加过渡效果），而实际使用是通过 `el-table` 的 `row-class-name` 的函数属性值的方式，不存在响应式的绑定。

因此，可以改成通过 `Object.defineProperty` 添加 `parent` 属性，并设置 `enumerable` 属性为 `false`，因为 `JSON.stringify` 方法不会对不可枚举的变量进行转换，从而避免了循环引用的问题，又保证当前的 `parent` 在 child row 上可用。
