### PR TITLE
docs: 在 basic 示例中增加 formatter 用法

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -13,6 +13,11 @@ export default {
         {prop: 'date', label: '日期'},
         {prop: 'name', label: '姓名'},
         {prop: 'address', label: '地址'},
+        {
+          prop: 'status',
+          label: '状态',
+          formatter: row => (row.date === '2016-05-02' ? '启用' : '禁用')
+        }
       ],
       form: [
         {


### PR DESCRIPTION
## Why
之前将文档的 mock 接口从 easy-mock 更换到 eolinker 时，因为丢失了大部分原数据，所以现在的示例数据是重新设计的（参考的 [el-table](https://element.eleme.cn/#/zh-CN/component/table)）

因此 basic 示例中原来有的 formatter 示例，重新设计时我没考虑到要恢复

## Docs
![image](https://user-images.githubusercontent.com/19591950/69301077-ffb19800-0c4f-11ea-86a7-87edeab5b0e7.png)
