### PR TITLE
fix: onDelete没有抛出异常的问题 

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -502,7 +502,12 @@ export default {
      */
     onDelete: {
       type: Function,
-      default: undefined
+      default(data) {
+        const ids = Array.isArray(data)
+          ? data.map(v => v[this.id]).join(',')
+          : data[this.id]
+        return this.$axios.delete(this.url + '/' + ids)
+      }
     },
     /**
      * 是否分页。如果不分页，则请求传参page=-1
@@ -1049,23 +1054,12 @@ export default {
           instance.confirmButtonLoading = true
 
           try {
-            if (this.onDelete) {
-              // 自定义删除逻辑
-              if (this.hasSelect) {
-                await this.onDelete(
-                  this.single ? this.selected[0] : this.selected
-                )
-              } else {
-                await this.onDelete(row)
-              }
-            } else if (this.hasSelect) {
-              // 多选模式
-              await this.$axios.delete(
-                this.url + '/' + this.selected.map(v => v[this.id]).join(',')
+            if (this.hasSelect) {
+              await this.onDelete(
+                this.single ? this.selected[0] : this.selected
               )
             } else {
-              // 单个删除
-              await this.$axios.delete(this.url + '/' + row[this.id])
+              await this.onDelete(row)
             }
             done()
             this.showMessage(true)
@@ -1084,7 +1078,8 @@ export default {
               this.page--
             this.getList()
           } catch (error) {
-            // do nothing
+            console.warn(error.message)
+            throw error
           } finally {
             instance.confirmButtonLoading = false
           }
@@ -1128,9 +1123,7 @@ export default {
       return tmp
     },
     showRow({row}) {
-      const show = row.parent
-        ? row.parent._expanded && row.parent._show
-        : true
+      const show = row.parent ? row.parent._expanded && row.parent._show : true
       row._show = show
       return show ? 'row-show' : 'row-hide'
     },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1123,7 +1123,7 @@ export default {
       return tmp
     },
     showRow({row}) {
-      const show = row.parent ? row.parent._expanded && row.parent._show : true
+      const show = !row.parent || (row.parent._expanded && row.parent._show)
       row._show = show
       return show ? 'row-show' : 'row-hide'
     },


### PR DESCRIPTION
## Why
尝试了下onDelete示例，发现点击确认删除按钮没有任何反应。调试后，发现是onDelete逻辑报错，内部只是catch了没有反应。

## How
1. 现在onDefaultDelete在catch error后会`console.warn(error.message)`然后再throw error
2. 给mock的数据加上id字段，否则onDelete示例会报错

## Test
删除逻辑正常
![image](https://user-images.githubusercontent.com/19591950/69406843-01598980-0d3e-11ea-8bf1-924c96a58075.png)

## Docs
现在onDelete示例能正常删除了
