### PR TITLE
feat: 暴露 correctPage API

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ export default {
 this.$refs.dataTable.getList()
 ```
 
-## 自己实现 delete 操作，同时实现删除最后一页时，返回上一页
+## 自己实现 delete 操作，同时实现删除最后一页时，返回正确的最后一页
 
 ### 场景
 1. 因为业务需求，data-table 默认的删除确认框不满足需求
@@ -28,7 +28,7 @@ this.$refs.dataTable.getList()
 
 ### 解决方案
 1. 自己实现删除操作
-2. 调用 correctPage 判断是否返回上一页
+2. 调用 correctPage 判断是否返回正确的最后一页
 3. 调用 getList 刷新列表
 ```html
 <template>
@@ -47,7 +47,7 @@ export default {
             this.$axios.delete('delete this row', {
               id: row.id
             }).then(() => {
-              // 判断删除后是否需要返回上一页
+              // 判断删除后是否返回正确的最后一页
               this.$refs.dataTable.correctPage()
 
               // 删除后刷新列表

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,7 +32,7 @@ this.$refs.dataTable.getList()
 3. 调用 getList 刷新列表
 ```html
 <template>
-  <el-data-table $refs="dataTable" :extraButtons="extraButtons">
+  <el-data-table ref="dataTable" :extraButtons="extraButtons">
 </template>
 
 <script>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,49 @@ export default {
 this.$refs.dataTable.getList()
 ```
 
+## 自己实现 delete 操作，同时实现删除最后一页时，返回上一页
+
+### 场景
+1. 因为业务需求，data-table 默认的删除确认框不满足需求
+2. 自己在外部使用 extra-buttons 实现 delete 操作
+3. 遇到了[最后一页删到空，页码出现错误](https://github.com/FEMessage/el-data-table/issues/223)的问题
+
+### 解决方案
+1. 自己实现删除操作
+2. 调用 shouldBackPrevPage 判断是否返回上一页
+3. 调用 getList 刷新列表
+```html
+<template>
+  <el-data-table $refs="dataTable" :extraButtons="extraButtons">
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      extraButtons: [
+        {
+          type: 'danger',
+          text: '删除',
+          atClick(row) {
+            this.$axios.delete('delete this row', {
+              id: row.id
+            }).then(() => {
+              // 判断删除后是否需要返回上一页
+              this.$refs.dataTable.shouldBackPrevPage()
+
+              // 删除后刷新列表
+              this.$refs.dataTable.getList()
+            })
+          }
+        }
+      ]
+    }
+  }
+}
+</script>
+```
+
 ## 查询后刷新
 
 ### 场景

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -48,7 +48,7 @@ export default {
               id: row.id
             }).then(() => {
               // 判断删除后是否需要返回上一页
-              this.$refs.dataTable.shouldBackPrevPage()
+              this.$refs.dataTable.correctPage()
 
               // 删除后刷新列表
               this.$refs.dataTable.getList()

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ this.$refs.dataTable.getList()
 
 ### 解决方案
 1. 自己实现删除操作
-2. 调用 shouldBackPrevPage 判断是否返回上一页
+2. 调用 correctPage 判断是否返回上一页
 3. 调用 getList 刷新列表
 ```html
 <template>

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1063,19 +1063,9 @@ export default {
             }
             done()
             this.showMessage(true)
-            let deleteCount = 1
-            if (this.hasSelect) {
-              deleteCount = this.selected.length
-              this.clearSelection()
-            }
-            const remain = this.data.length - deleteCount
-            const lastPage = Math.ceil(this.total / this.size)
-            if (
-              remain === 0 &&
-              this.page === lastPage &&
-              this.page > defaultFirstPage
-            )
-              this.page--
+
+            this.shouldBackPrevPage()
+
             this.getList()
           } catch (error) {
             console.warn(error.message)
@@ -1088,6 +1078,27 @@ export default {
         /*取消*/
       })
     },
+
+    /**
+     * 判断是否返回上一页
+     * @public
+     */
+    shouldBackPrevPage() {
+      let deleteCount = 1
+      if (this.hasSelect) {
+        deleteCount = this.selected.length
+        this.clearSelection()
+      }
+      const remain = this.data.length - deleteCount
+      const lastPage = Math.ceil(this.total / this.size)
+      if (
+        remain === 0 &&
+        this.page === lastPage &&
+        this.page > defaultFirstPage
+      )
+        this.page--
+    },
+
     // 树形table相关
     // https://github.com/PanJiaChen/vue-element-admin/tree/master/src/components/TreeTable
     tree2Array(data, expandAll, parent = null, level = null) {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1064,7 +1064,7 @@ export default {
             done()
             this.showMessage(true)
 
-            this.shouldBackPrevPage()
+            this.correctPage()
 
             this.getList()
           } catch (error) {
@@ -1083,7 +1083,7 @@ export default {
      * 判断是否返回上一页
      * @public
      */
-    shouldBackPrevPage() {
+    correctPage() {
       let deleteCount = 1
       if (this.hasSelect) {
         deleteCount = this.selected.length


### PR DESCRIPTION
close #241 
close #238

## New Feature
make methods correctPage public 
抽离判断返回上一页的逻辑,方便自定义实现 delete 时,保持与 defalutDelete 行为一致

## Docs

详情看 faq

- 暴露的公共方法名为 correctPage 因为讨论发现这个操作不一定是返回上一页，而是回到正确的最后一页