### PR TITLE
feat: 刷新列表时提供一个 flag 判断是否显示 loading

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -822,11 +822,11 @@ export default {
   },
   methods: {
     /**
-     * 手动刷新列表数据
+     * 手动刷新列表数据，选项的默认值为: { loading: true }
      * @public
-     * @param {boolean} shouldLoading - 刷新列表时，是否显示 loading
+     * @param {object} options 方法选项
      */
-    getList(shouldLoading = true) {
+    getList({loading = true} = {}) {
       const {url} = this
 
       if (!url) {
@@ -862,7 +862,7 @@ export default {
         queryUtil.stringify(query, '=', '&')
 
       // 请求开始
-      this.loading = shouldLoading
+      this.loading = loading
 
       // 存储query记录, 便于后面恢复
       if (this.saveQuery) {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -824,9 +824,9 @@ export default {
     /**
      * 手动刷新列表数据
      * @public
-     * @param {boolean} saveQuery - 是否保存query到路由上
+     * @param {boolean} shouldLoading - 刷新列表时，是否显示 loading
      */
-    getList() {
+    getList(shouldLoading = true) {
       const {url} = this
 
       if (!url) {
@@ -862,7 +862,7 @@ export default {
         queryUtil.stringify(query, '=', '&')
 
       // 请求开始
-      this.loading = true
+      this.loading = shouldLoading
 
       // 存储query记录, 便于后面恢复
       if (this.saveQuery) {


### PR DESCRIPTION
close #244 

## Why

- 在轮询更新列表状态的场景下，getList 默认的 loading 会打断用户的操作

## Test
![image](https://user-images.githubusercontent.com/27187946/69708184-22531d80-1136-11ea-813e-5817e2467466.png)

## After
- 调用 getList 时可以传一个 false 来禁用 loading
