### PR TITLE
feat: extraButton添加函数类型的disabled属性

### DIFF
--- a/docs/extra-buttons.md
+++ b/docs/extra-buttons.md
@@ -17,6 +17,7 @@ export default {
       extraButtons: [
         {
           type: 'success',
+          disabled: row => row.date === '2016-05-04',
           text: row => row.status === 'normal' ? '禁用' : '启用',
           atClick(row) {
             alert(row.name)

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -403,7 +403,7 @@ export default {
     },
     /**
      * 操作列的自定义按钮, 渲染的是element-ui的button, 支持包括style在内的以下属性:
-     * {type: '', text: '', atClick: row => Promise.resolve(), show: row => return true时显示 }
+     * {type: '', text: '', atClick: row => Promise.resolve(), show: row => return true时显示, disabled: row => return true时禁用 }
      * 点击事件 row参数 表示当前行数据, 需要返回Promise, 默认点击后会刷新table, resolve(false) 则不刷新
      */
     extraButtons: {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -206,6 +206,7 @@
                 :click="btn.atClick"
                 :params="scope.row"
                 :callback="getList"
+                :disabled="'disabled' in btn ? btn.disabled(scope.row) : false"
               >
                 {{
                   typeof btn.text === 'function'


### PR DESCRIPTION

## Why
操作栏按钮需要进行个别的禁用，并根据当前行的数据展示是否禁用的状态

## How
类似show，给extraButton提供一个函数类型的属性disabled，函数第一个参数可以获取到该行的数据，自行处理逻辑，返回一个布尔值使得按钮是否为禁用状态，返回true为禁用，false为不禁用，默认不禁用

## Test
表格配置添加一个extraButton
extraButtons: [
        {
          text: '禁用',
          disabled: (row)=>{
            if (row.xx=='xx') return true
          },
        },
      ]
