### PR TITLE
fix: 修复 el-pagination 值错误，可点击问题

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -887,7 +887,8 @@ export default {
             this.total = data.length
           } else {
             data = _get(resp, this.dataPath) || []
-            this.total = _get(resp, this.totalPath)
+            // 获取不到值得时候返回 undefined, el-pagination 接收一个 null 后者 undefined 会导致没数据但是下一页可点击
+            this.total = _get(resp, this.totalPath) || 0
           }
 
           this.data = data

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -887,7 +887,7 @@ export default {
             this.total = data.length
           } else {
             data = _get(resp, this.dataPath) || []
-            // 获取不到值得时候返回 undefined, el-pagination 接收一个 null 后者 undefined 会导致没数据但是下一页可点击
+            // 获取不到值得时候返回 undefined, el-pagination 接收一个 null 或者 undefined 会导致没数据但是下一页可点击
             this.total = _get(resp, this.totalPath) || 0
           }
 


### PR DESCRIPTION
## Why
因为 el-pagination 接收到的值，如果是 null 后者 undefined 的话，会导致 下一页可以被点击，被点击的话会触发组件的 getList。

## How
_get 情况下，如果接口返回的是 null 的话，_get 获取不到值就会是 undefined 值
```diff
- this.total = _get(resp, this.totalPath)
+ this.total = _get(resp, this.totalPath) || 0
````
