### PR TITLE
fix: header 部分仅有 slot-header 时，该 slot 未显示的 bug

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -769,7 +769,8 @@ export default {
         this.hasNew ||
         (this.hasSelect && this.hasDelete) ||
         this.headerButtons.length ||
-        this.canSearchCollapse
+        this.canSearchCollapse ||
+        this.$scopedSlots.header
       )
     },
     _extraBody() {


### PR DESCRIPTION
## Why
hasHeader 的判断里没有包括 `this.$slots.header`

### 为什么需要 hasHeader
hasHeader 存在是因为整个 header 是被包在一个 el-form 里。
el-form 存在是因为需要它的`margin-bottom: 22px`

## Test
给示例`slot-header`加上`hasNew: false`。现在 slot 能正常显示了
![image](https://user-images.githubusercontent.com/19591950/70130305-45904680-16bb-11ea-8dd2-01c468186d9d.png)

