### PR TITLE
feat: 支持多级表头

### DIFF
--- a/docs/multi-level-header.md
+++ b/docs/multi-level-header.md
@@ -1,0 +1,52 @@
+只需要在`columns`子项里嵌套`columns`数组，就可以实现多级表头
+
+```vue
+<template>
+  <el-data-table v-bind="$data" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://mockapi.eolinker.com/LEcMEAs713a1b6dfad35518033b046ca69b4cffb478dc4d/el-data-table?q=basic',
+      columns: [
+        {prop: 'date', label: '日期'},
+        {
+          prop: 'info',
+          label: '个人信息',
+          columns: [
+            {prop: 'name', label: '姓名'},
+            {prop: 'address', label: '地址'}
+          ]
+        }
+      ],
+      form: [
+        {
+          type: 'input',
+          id: 'name',
+          label: '姓名',
+          rules: [
+            {
+              required: true,
+              message: '请输入姓名',
+              trigger: 'blur',
+              transform: v => v && v.trim()
+            }
+          ],
+          el: {placeholder: '请输入姓名'}
+        }
+      ],
+      searchForm: [
+        {
+          el: {placeholder: '请输入'},
+          label: '姓名',
+          id: 'name',
+          type: 'input'
+        }
+      ],
+      hasView: true
+    }
+  }
+}
+</script>
+```

--- a/docs/multi-level-header.md
+++ b/docs/multi-level-header.md
@@ -1,5 +1,6 @@
 只需要在columns子项里嵌套columns数组，就可以实现多级表头
 
+**二级**
 ```vue
 <template>
   <el-data-table v-bind="$data" />
@@ -12,13 +13,69 @@ export default {
       columns: [
         {prop: 'date', label: '日期'},
         {
-          prop: 'info',
           label: '个人信息',
           columns: [
             {prop: 'name', label: '姓名'},
             {prop: 'address', label: '地址'}
           ]
         }
+      ],
+      form: [
+        {
+          type: 'input',
+          id: 'name',
+          label: '姓名',
+          rules: [
+            {
+              required: true,
+              message: '请输入姓名',
+              trigger: 'blur',
+              transform: v => v && v.trim()
+            }
+          ],
+          el: {placeholder: '请输入姓名'}
+        }
+      ],
+      searchForm: [
+        {
+          el: {placeholder: '请输入'},
+          label: '姓名',
+          id: 'name',
+          type: 'input'
+        }
+      ],
+      hasView: true
+    }
+  }
+}
+</script>
+```
+
+**更多级**
+```vue
+<template>
+  <el-data-table v-bind="$data" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://mockapi.eolinker.com/LEcMEAs713a1b6dfad35518033b046ca69b4cffb478dc4d/el-data-table?q=basic',
+      columns: [
+        {
+          label: '这是一级表头',
+          columns: [
+            {prop: 'date', label: '日期'},
+            {
+              prop: 'info',
+              label: '个人信息',
+              columns: [
+                {prop: 'name', label: '姓名'},
+                {prop: 'address', label: '地址'}
+              ]
+            }
+          ]
+        },
       ],
       form: [
         {

--- a/docs/multi-level-header.md
+++ b/docs/multi-level-header.md
@@ -1,4 +1,4 @@
-只需要在`columns`子项里嵌套`columns`数组，就可以实现多级表头
+只需要在columns子项里嵌套columns数组，就可以实现多级表头
 
 ```vue
 <template>

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -9,7 +9,7 @@ export default {
     if (props.columns) {
       children = props.columns.map(column =>
         h('el-data-table-column', {
-          props: Object.assign({}, defaltAttrs, column)
+          props: Object.assign({}, defaultAttrs, column)
         })
       )
     }

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -1,0 +1,22 @@
+const defaltAttrs = {
+  align: 'center'
+}
+export default {
+  name: 'el-data-table-column',
+  functional: true,
+  render(h, {data, props}) {
+    let children = []
+    if (props.columns) {
+      children = props.columns.map(column =>
+        h('el-table-column', {
+          props: Object.assign({}, defaltAttrs, column)
+        })
+      )
+    }
+    data.props = {
+      ...defaltAttrs,
+      ...data.props
+    }
+    return h('el-table-column', data, children)
+  }
+}

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -1,4 +1,4 @@
-const defaltAttrs = {
+const defaultAttrs = {
   align: 'center'
 }
 export default {

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -8,7 +8,7 @@ export default {
     let children = []
     if (props.columns) {
       children = props.columns.map(column =>
-        h('el-table-column', {
+        h('el-data-table-column', {
           props: Object.assign({}, defaltAttrs, column)
         })
       )

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -14,7 +14,7 @@ export default {
       )
     }
     data.props = {
-      ...defaltAttrs,
+      ...defaultAttrs,
       ...data.props
     }
     return h('el-table-column', data, children)

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -93,9 +93,9 @@
         <template v-if="isTree">
           <!--有多选-->
           <template v-if="hasSelect">
-            <el-table-column key="selection-key" v-bind="columns[0]" />
+            <el-data-table-column key="selection-key" v-bind="columns[0]" />
 
-            <el-table-column key="tree-ctrl" v-bind="columns[1]">
+            <el-data-table-column key="tree-ctrl" v-bind="columns[1]">
               <template slot-scope="scope">
                 <span
                   v-for="space in scope.row._level"
@@ -113,9 +113,9 @@
                 </span>
                 {{ scope.row[columns[1].prop] }}
               </template>
-            </el-table-column>
+            </el-data-table-column>
 
-            <el-table-column
+            <el-data-table-column
               v-for="col in columns.filter((c, i) => i !== 0 && i !== 1)"
               :key="col.prop"
               v-bind="col"
@@ -124,8 +124,8 @@
 
           <!--无选择-->
           <template v-else>
-            <!--展开这列, 丢失 el-table-column属性-->
-            <el-table-column key="tree-ctrl" v-bind="columns[0]">
+            <!--展开这列, 丢失 el-data-table-column属性-->
+            <el-data-table-column key="tree-ctrl" v-bind="columns[0]">
               <template slot-scope="scope">
                 <span
                   v-for="space in scope.row._level"
@@ -144,9 +144,9 @@
                 </span>
                 {{ scope.row[columns[0].prop] }}
               </template>
-            </el-table-column>
+            </el-data-table-column>
 
-            <el-table-column
+            <el-data-table-column
               v-for="col in columns.filter((c, i) => i !== 0)"
               :key="col.prop"
               v-bind="col"
@@ -156,7 +156,7 @@
 
         <!--非树-->
         <template v-else>
-          <el-table-column
+          <el-data-table-column
             v-for="col in columns"
             :key="col.prop"
             v-bind="col"
@@ -164,7 +164,7 @@
         </template>
 
         <!--默认操作列-->
-        <el-table-column
+        <el-data-table-column
           v-if="hasOperation"
           label="操作"
           v-bind="operationAttrs"
@@ -224,7 +224,7 @@
               删除
             </self-loading-button>
           </template>
-        </el-table-column>
+        </el-data-table-column>
 
         <!--@slot 自定义操作列, 当extraButtons不满足需求时可以使用 -->
         <slot />
@@ -267,6 +267,7 @@ import _get from 'lodash.get'
 import SelfLoadingButton from './components/self-loading-button.vue'
 import TheDialog, {dialogModes} from './components/the-dialog.vue'
 import SearchForm from './components/search-form.vue'
+import ElDataTableColumn from './components/el-data-table-column'
 import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
 import getLocatedSlotKeys from './utils/extract-keys'
@@ -300,7 +301,8 @@ export default {
   components: {
     SelfLoadingButton,
     TheDialog,
-    SearchForm
+    SearchForm,
+    ElDataTableColumn
   },
 
   props: {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
不满足当前项目需求

## How
1. 封装一个 `el-data-table-column` 的容器组件，当传入 `columns` 时递归本身
2. 将 `el-table-column` 替换成 `el-data-table-column` 

## Test
在`columns`子项里嵌套`columns`数组
```js
  columns: [
    { prop: 'date', label: '日期' },
    {
      prop: 'info',
      label: '个人信息',
      columns: [
        { prop: 'name', label: '姓名' },
        { prop: 'address', label: '地址' }
      ]
    }
  ]
```
效果图
![](https://i.loli.net/2019/12/09/jkv8KuFOYy46tQN.png)

## Docs
- docs/multi-level-header.md
