### PR TITLE
fix: getList 出错时设置 total = 0

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -925,6 +925,7 @@ export default {
            * @event error
            */
           this.$emit('error', err)
+          this.total = 0
           this.loading = false
         })
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -791,9 +791,9 @@
     minimist "^1.2.0"
 
 "@femessage/el-form-renderer@^1.6.0":
-  version "1.11.2"
-  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.11.2.tgz#bcd209fa3f9057de6463d91aa71b052219764eaa"
-  integrity sha1-vNIJ+j+QV95kY9kapxsFIhl2Tqo=
+  version "1.12.1"
+  resolved "https://registry.npm.taobao.org/@femessage/el-form-renderer/download/@femessage/el-form-renderer-1.12.1.tgz#07c021f56ad25b11040d605bccf9d369af9a1861"
+  integrity sha1-B8Ah9WrSWxEEDWBbzPnTaa+aGGE=
   dependencies:
     lodash.get "^4.4.2"
     lodash.set "^4.3.2"


### PR DESCRIPTION
## Why
total 不为 0 的话，用户仍可翻页

## How
1. 顺手更新了 el-form-renderer 的依赖（之前向别人用 searchForm 演示 remote 功能时，发现 styleguide 的 el-form-renderer 版本不够新
2. getList 的 catch block 里设置 total = 0

## Test
直接在 this.$axios.then 里 throw new Error()
### Before
![image](https://user-images.githubusercontent.com/19591950/70607687-e04bd080-1c39-11ea-8dc3-ba1a5edceda9.png)

### After
![image](https://user-images.githubusercontent.com/19591950/70607679-dc1fb300-1c39-11ea-975d-097669e626f6.png)

