### PR TITLE
fix: 当url从有重新置空时,数据也置空

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -794,7 +794,10 @@ export default {
   watch: {
     url: {
       handler(val) {
-        if (!val) return
+        if(!val) {
+          this.data = [];
+          return;
+        }
         this.page = defaultFirstPage
         // mounted处有updateForm的行为，所以至少在初始执行时要等到nextTick
         this.$nextTick(this.getList)


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
有情景是url从有重新置为空时，table数据也需要同步置为空（目前是没有做任何操作，会导致有旧数据残留）

## How
Describe your steps:
1. one step
2. two step...

You may use xmind or other mind map to show you logic

## Test
Show your test case

you'd better show `before` and `after` 

## Docs
It there requires a change to the documentation？
