### PR TITLE
feat: 自定义删除弹窗文案

### DIFF
--- a/docs/custom-text.md
+++ b/docs/custom-text.md
@@ -38,7 +38,7 @@ export default {
       deleteText: '移除',
       deleteMessage(data) {
         // 开启多选且 single = false（default）时 data 为数组，其他情况下为行数据对象。数据和传给 onDelete 的是一样
-        const name = Array.isArray(data) ? data.map(r => r.name).join(',') : data.name
+        const name = data.map(r => r.name).join(',')
         return `确认移除 ${name} 吗？`
       }
     }

--- a/docs/custom-text.md
+++ b/docs/custom-text.md
@@ -1,4 +1,4 @@
-通过prop自定义新增、修改、删除等按钮的文案
+自定义新增、修改、删除按钮以及删除提示框的文案
 
 ```vue
 <template>
@@ -31,10 +31,13 @@ export default {
         },
       ],
       hasView: true,
-      hasDelete: false,
       newText: '创建',
       editText: '编辑',
       viewText: '详情',
+      deleteText: '移除',
+      deleteMessage(row) {
+        return `确认移除 ${row.name} 吗？`
+      }
     }
   }
 }

--- a/docs/custom-text.md
+++ b/docs/custom-text.md
@@ -37,7 +37,7 @@ export default {
       viewText: '详情',
       deleteText: '移除',
       deleteMessage(data) {
-        // 只有在开启多选且选中两项或以上时，data 为数组。数据和传给 onDelete 的是一样
+        // 开启多选且 single = false（default）时 data 为数组，其他情况下为行数据对象。数据和传给 onDelete 的是一样
         const name = Array.isArray(data) ? data.map(r => r.name).join(',') : data.name
         return `确认移除 ${name} 吗？`
       }

--- a/docs/custom-text.md
+++ b/docs/custom-text.md
@@ -10,6 +10,7 @@ export default {
     return {
       url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
       columns: [
+        {type: 'selection'},
         {prop: 'date', label: '日期'},
         {prop: 'name', label: '姓名'},
         {prop: 'address', label: '地址'},
@@ -35,8 +36,9 @@ export default {
       editText: '编辑',
       viewText: '详情',
       deleteText: '移除',
-      deleteMessage(row) {
-        return `确认移除 ${row.name} 吗？`
+      deleteMessage(data) {
+        const name = Array.isArray(data) ? data.map(r => r.name).join(',') : data.name
+        return `确认移除 ${name} 吗？`
       }
     }
   }

--- a/docs/custom-text.md
+++ b/docs/custom-text.md
@@ -37,6 +37,7 @@ export default {
       viewText: '详情',
       deleteText: '移除',
       deleteMessage(data) {
+        // 只有在开启多选且选中两项或以上时，data 为数组。数据和传给 onDelete 的是一样
         const name = Array.isArray(data) ? data.map(r => r.name).join(',') : data.name
         return `确认移除 ${name} 吗？`
       }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -64,7 +64,7 @@
                 : !selected.length
             "
             @click="onDefaultDelete($event)"
-            >删除</el-button
+            >{{ deleteText }}</el-button
           >
           <el-button
             v-if="canSearchCollapse"
@@ -222,7 +222,7 @@
               :is-text="operationButtonType === 'text'"
               @click="onDefaultDelete(scope.row)"
             >
-              删除
+              {{ deleteText }}
             </self-loading-button>
           </template>
         </el-data-table-column>
@@ -461,6 +461,22 @@ export default {
     viewText: {
       type: String,
       default: '查看'
+    },
+    /**
+     * 删除按钮文案
+     */
+    deleteText: {
+      type: String,
+      default: '删除'
+    },
+    /**
+     * 删除提示语，接受行数据 row，返回字符串
+     */
+    deleteMessage: {
+      type: Function,
+      default() {
+        return `确认${this.deleteText}吗`
+      }
     },
     /**
      * 某行数据是否可以删除, 返回true表示可以, 控制的是单选时单行的删除按钮
@@ -1039,7 +1055,7 @@ export default {
       }
     },
     onDefaultDelete(row) {
-      this.$confirm('确认删除吗', '提示', {
+      this.$confirm(this.deleteMessage(row), '提示', {
         type: 'warning',
         confirmButtonClass: 'el-button--danger',
         beforeClose: async (action, instance, done) => {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -475,7 +475,7 @@ export default {
     deleteMessage: {
       type: Function,
       default() {
-        return `确认${this.deleteText}吗`
+        return `确认${this.deleteText}吗?`
       }
     },
     /**

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -470,7 +470,7 @@ export default {
       default: '删除'
     },
     /**
-     * 删除提示语，接受行数据 row，返回字符串
+     * 删除提示语，接受要删除的数据（单选时为 row，多选时为 row 的数组），返回字符串
      */
     deleteMessage: {
       type: Function,
@@ -1055,7 +1055,12 @@ export default {
       }
     },
     onDefaultDelete(row) {
-      this.$confirm(this.deleteMessage(row), '提示', {
+      const data = this.hasSelect
+        ? this.single
+          ? this.selected[0]
+          : this.selected
+        : row
+      this.$confirm(this.deleteMessage(data), '提示', {
         type: 'warning',
         confirmButtonClass: 'el-button--danger',
         beforeClose: async (action, instance, done) => {
@@ -1064,13 +1069,7 @@ export default {
           instance.confirmButtonLoading = true
 
           try {
-            if (this.hasSelect) {
-              await this.onDelete(
-                this.single ? this.selected[0] : this.selected
-              )
-            } else {
-              await this.onDelete(row)
-            }
+            await this.onDelete(data)
             done()
             this.showMessage(true)
 


### PR DESCRIPTION
## Why
常见需求。大量用户弃用原生 delete 使用 extraButtons 就是因此

## Test
### 单选
![image](https://user-images.githubusercontent.com/19591950/71402701-8949f080-2668-11ea-940e-d33fd41714b3.png)
### 多选
![image](https://user-images.githubusercontent.com/19591950/71404121-aa144500-266c-11ea-8996-aaa8b8d4a3ff.png)

## Docs
文档 new-text 改名为 custom-text，表示这里演示自定义文案的例子
