### PR TITLE
fix: 去除默认居中

### DIFF
--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -1,6 +1,3 @@
-const defaultAttrs = {
-  align: 'center'
-}
 export default {
   name: 'el-data-table-column',
   functional: true,
@@ -9,13 +6,9 @@ export default {
     if (props.columns) {
       children = props.columns.map(column =>
         h('el-data-table-column', {
-          props: Object.assign({}, defaultAttrs, column)
+          props: column
         })
       )
-    }
-    data.props = {
-      ...defaultAttrs,
-      ...data.props
     }
     return h('el-table-column', data, children)
   }


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
之前的 PR 中引入了默认居中，为了不影响到其他项目，所以去除默认居中。

## How
1. 去除 `defaultAttrs `