### PR TITLE
fix: columns property align not work

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -10,7 +10,7 @@ export default {
     return {
       url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
       columns: [
-        {prop: 'date', label: '日期'},
+        {prop: 'date', label: '日期', align: 'center'},
         {prop: 'name', label: '姓名'},
         {prop: 'address', label: '地址'},
       ],

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -1,20 +1,17 @@
-const defaultAttrs = {
-  align: 'center'
-}
 export default {
   name: 'el-data-table-column',
   functional: true,
   render(h, {data, props}) {
     let children = []
+    const align = props.align
     if (props.columns) {
       children = props.columns.map(column =>
         h('el-data-table-column', {
-          props: Object.assign({}, defaultAttrs, column)
+          props: Object.assign({}, column, {align})
         })
       )
     }
     data.props = {
-      ...defaultAttrs,
       ...data.props
     }
     return h('el-table-column', data, children)

--- a/src/components/el-data-table-column.js
+++ b/src/components/el-data-table-column.js
@@ -7,7 +7,7 @@ export default {
     if (props.columns) {
       children = props.columns.map(column =>
         h('el-data-table-column', {
-          props: Object.assign({}, column, {align})
+          props: Object.assign({}, {align}, column)
         })
       )
     }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -93,9 +93,17 @@
         <template v-if="isTree">
           <!--有多选-->
           <template v-if="hasSelect">
-            <el-data-table-column key="selection-key" v-bind="columns[0]" />
+            <el-data-table-column
+              key="selection-key"
+              v-bind="columns[0]"
+              :align="columnsAlign"
+            />
 
-            <el-data-table-column key="tree-ctrl" v-bind="columns[1]">
+            <el-data-table-column
+              key="tree-ctrl"
+              v-bind="columns[1]"
+              :align="columnsAlign"
+            >
               <template slot-scope="scope">
                 <span
                   v-for="space in scope.row._level"
@@ -119,13 +127,18 @@
               v-for="col in columns.filter((c, i) => i !== 0 && i !== 1)"
               :key="col.prop"
               v-bind="col"
+              :align="columnsAlign"
             />
           </template>
 
           <!--无选择-->
           <template v-else>
             <!--展开这列, 丢失 el-data-table-column属性-->
-            <el-data-table-column key="tree-ctrl" v-bind="columns[0]">
+            <el-data-table-column
+              key="tree-ctrl"
+              v-bind="columns[0]"
+              :align="columnsAlign"
+            >
               <template slot-scope="scope">
                 <span
                   v-for="space in scope.row._level"
@@ -150,6 +163,7 @@
               v-for="col in columns.filter((c, i) => i !== 0)"
               :key="col.prop"
               v-bind="col"
+              :align="columnsAlign"
             />
           </template>
         </template>
@@ -160,6 +174,7 @@
             v-for="col in columns"
             :key="col.prop"
             v-bind="col"
+            :align="columnsAlign"
           />
         </template>
 
@@ -168,6 +183,7 @@
           v-if="hasOperation"
           label="操作"
           v-bind="operationAttrs"
+          :align="columnsAlign"
         >
           <template slot-scope="scope">
             <self-loading-button
@@ -753,7 +769,6 @@ export default {
   data() {
     return {
       data: [],
-      hasSelect: this.columns.length && this.columns[0].type == 'selection',
       size: this.paginationSize || this.paginationSizes[0],
       page: defaultFirstPage,
       // https://github.com/ElemeFE/element/issues/1153
@@ -773,6 +788,16 @@ export default {
     }
   },
   computed: {
+    hasSelect() {
+      return this.columns.length && this.columns[0].type == 'selection'
+    },
+    columnsAlign() {
+      if (this.columns.some(col => col.columns && col.columns.length)) {
+        return 'center'
+      } else {
+        return ''
+      }
+    },
     routerMode() {
       return this.$router ? this.$router.mode : 'hash'
     },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -786,6 +786,7 @@ export default {
     },
     columnsAlign() {
       if (this.columns.some(col => col.columns && col.columns.length)) {
+        // 多级表头默认居中
         return 'center'
       } else {
         return ''

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -95,14 +95,12 @@
           <template v-if="hasSelect">
             <el-data-table-column
               key="selection-key"
-              v-bind="columns[0]"
-              :align="columnsAlign"
+              v-bind="{align: columnsAlign, ...columns[0]}"
             />
 
             <el-data-table-column
               key="tree-ctrl"
-              v-bind="columns[1]"
-              :align="columnsAlign"
+              v-bind="{align: columnsAlign, ...columns[1]}"
             >
               <template slot-scope="scope">
                 <span
@@ -126,8 +124,7 @@
             <el-data-table-column
               v-for="col in columns.filter((c, i) => i !== 0 && i !== 1)"
               :key="col.prop"
-              v-bind="col"
-              :align="columnsAlign"
+              v-bind="{align: columnsAlign, ...col}"
             />
           </template>
 
@@ -136,8 +133,7 @@
             <!--展开这列, 丢失 el-data-table-column属性-->
             <el-data-table-column
               key="tree-ctrl"
-              v-bind="columns[0]"
-              :align="columnsAlign"
+              v-bind="{align: columnsAlign, ...columns[0]}"
             >
               <template slot-scope="scope">
                 <span
@@ -162,8 +158,7 @@
             <el-data-table-column
               v-for="col in columns.filter((c, i) => i !== 0)"
               :key="col.prop"
-              v-bind="col"
-              :align="columnsAlign"
+              v-bind="{align: columnsAlign, ...col}"
             />
           </template>
         </template>
@@ -173,8 +168,7 @@
           <el-data-table-column
             v-for="col in columns"
             :key="col.prop"
-            v-bind="col"
-            :align="columnsAlign"
+            v-bind="{align: columnsAlign, ...col}"
           />
         </template>
 
@@ -182,8 +176,7 @@
         <el-data-table-column
           v-if="hasOperation"
           label="操作"
-          v-bind="operationAttrs"
-          :align="columnsAlign"
+          v-bind="{align: columnsAlign, ...operationAttrs}"
         >
           <template slot-scope="scope">
             <self-loading-button


### PR DESCRIPTION
CLOSE #264 

## Why
- multi-level-header should align center but should not affect normal header
- fix issue #264

## How
create a computed property to define if multi-level header or not

if yes, render columns with align center
if not, render columns as before

More importantly, columns property can assign the computed property


## Test
after
![image](https://user-images.githubusercontent.com/27187946/71502195-c3ee9b80-28a9-11ea-81b4-bd02a9248a36.png)

![image](https://user-images.githubusercontent.com/27187946/71502200-cfda5d80-28a9-11ea-8282-b567c061e11a.png)


