### PR TITLE
docs: 公开 onDefaultDelete 方法

### DIFF
--- a/docs/on-default-delete.md
+++ b/docs/on-default-delete.md
@@ -1,0 +1,33 @@
+有时候，el-data-table 内置删除按钮的形式、数量不满足用户需求。那么用户可以在合适的时机自行调用内部方法来删除。
+下面的例子就是在多选的情况补回行删除按钮
+
+```vue
+<template>
+  <el-data-table v-bind="$data" ref="table" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
+      columns: [
+        {type: 'selection'},
+        {prop: 'date', label: '日期'},
+        {prop: 'name', label: '姓名'},
+        {prop: 'address', label: '地址'},
+      ],
+      extraButtons: [
+        {
+          type: 'danger',
+          text: '删除',
+          atClick: (row) => {
+            this.$refs.table.onDefaultDelete(row)
+            return false
+          }
+        },
+      ]
+    }
+  }
+}
+</script>
+```

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -58,12 +58,8 @@
             v-if="hasSelect && hasDelete"
             type="danger"
             :size="buttonSize"
-            :disabled="
-              single
-                ? !selected.length || selected.length > 1
-                : !selected.length
-            "
-            @click="onDefaultDelete($event)"
+            :disabled="selected.length === 0 || (single && selected.length > 1)"
+            @click="onDefaultDelete(single ? selected[0] : selected)"
             >{{ deleteText }}</el-button
           >
           <el-button
@@ -225,7 +221,7 @@
               </self-loading-button>
             </template>
             <self-loading-button
-              v-if="!hasSelect && hasDelete && canDelete(scope.row)"
+              v-if="hasDelete && canDelete(scope.row)"
               type="danger"
               :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"
@@ -493,7 +489,9 @@ export default {
       default: '删除'
     },
     /**
-     * 删除提示语，接受要删除的数据（单选时为 row，多选时为 row 的数组），返回字符串
+     * 删除提示语。接受要删除的数据（单个对象或数组）；返回字符串
+     * @param {object|object[]} 要删除的数据 - 单个对象或数组
+     * @return {string}
      */
     deleteMessage: {
       type: Function,
@@ -1110,12 +1108,7 @@ export default {
         done(false)
       }
     },
-    onDefaultDelete(row) {
-      const data = this.hasSelect
-        ? this.single
-          ? this.selected[0]
-          : this.selected
-        : row
+    onDefaultDelete(data) {
       this.$confirm(this.deleteMessage(data), '提示', {
         type: 'warning',
         confirmButtonClass: 'el-button--danger',

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -221,7 +221,7 @@
               </self-loading-button>
             </template>
             <self-loading-button
-              v-if="hasDelete && canDelete(scope.row)"
+              v-if="!hasSelect && hasDelete && canDelete(scope.row)"
               type="danger"
               :size="operationButtonType === 'text' ? '' : buttonSize"
               :is-text="operationButtonType === 'text'"

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1108,6 +1108,15 @@ export default {
         done(false)
       }
     },
+    /**
+     * 完整的删除方法，流程如下：
+     * 1. 弹出二次确认弹窗（使用 deleteMessage）；
+     * 2. 执行 onDelete，过程中确认按钮保持 loading；
+     * 3. 失败则报错误信息、弹窗不关闭；
+     * 4. 成功则报成功信息、弹窗关闭、重新请求数据、并校正页码（详见 correctPage）；
+     * @public
+     * @param {object|object[]} - 要删除的数据对象或数组
+     */
     onDefaultDelete(data) {
       this.$confirm(this.deleteMessage(data), '提示', {
         type: 'warning',


### PR DESCRIPTION
## Why
有时候内置的删除按钮不满足产品场景；那么 table 可以公开内部完整的经过实践的删除方法，方便前端用户根据场景去调用

## How
1. onDefaultDelete 参数传什么它删什么
2. 补充注释

## Docs
![image](https://user-images.githubusercontent.com/19591950/71567233-6bf9a400-2af8-11ea-985e-5d557b3477b5.png)

