### PR TITLE
feat: 新增表格单选（有缺陷暂不合并）

### DIFF
--- a/docs/has-radio-select.md
+++ b/docs/has-radio-select.md
@@ -1,0 +1,38 @@
+显示单选框
+
+```vue
+<template>
+  <div>
+    <el-data-table v-bind="$data" ref="dataTable" @selection-change="onSelectionChange" />
+    <div>selected: {{selected}}</div>
+    <el-button @click="clearSelection">取消选择</el-button>
+  </div>
+</template>
+ <script>
+export default {
+  data() {
+    return {
+      paginationSizes: [2, 4],
+      url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=persist-selection',
+      columns: [
+        {prop: 'id', label: 'id'},
+        {prop: 'name', label: '用户名'}
+      ],
+      hasNew: false,
+      hasOperation: true,
+      selected: [],
+      hasRadioSelect: true
+    }
+  },
+  methods: {
+    clearSelection() {
+        this.$refs.dataTable.radioVal = ''
+        this.$refs.dataTable.selected = []
+    },
+    onSelectionChange(val) {
+      this.selected = val
+    }
+  }
+}
+</script>
+```

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -167,6 +167,18 @@
 
         <!--非树-->
         <template v-else>
+          <template v-if="hasRadioSelect && !hasSelect">
+            <el-table-column label="" width="45">
+              <template slot-scope="scope">
+                <el-radio
+                  v-model="radioVal"
+                  :label="scope.row"
+                  @change="radioSelectBtn(scope.$index, scope.row)"
+                  ><i></i
+                ></el-radio>
+              </template>
+            </el-table-column>
+          </template>
           <el-data-table-column
             v-for="col in columns"
             :key="col.prop"
@@ -783,11 +795,19 @@ export default {
       default() {
         return {}
       }
+    },
+    /**
+     * 是否显示单选框
+     */
+    hasRadioSelect: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
       data: [],
+      radioVal: '', // 单选值
       size: this.paginationSize || this.paginationSizes[0],
       page: defaultFirstPage,
       // https://github.com/ElemeFE/element/issues/1153
@@ -991,7 +1011,12 @@ export default {
 
           // 开启persistSelection时，需要同步selected状态到el-table中
           this.$nextTick(() => {
-            this.selectStrategy.updateElTableSelection()
+            if (this.hasRadioSelect && !this.persistSelection) {
+              // why？clearSelection只针对Checkbox，故这么写
+              this.selected = []
+            }
+            this.persistSelection &&
+              this.selectStrategy.updateElTableSelection()
           })
         })
         .catch(err => {
@@ -1221,6 +1246,10 @@ export default {
     iconShow(index, record) {
       //      return index ===0 && record.children && record.children.length > 0;
       return record[this.treeChildKey] && record[this.treeChildKey].length > 0
+    },
+    radioSelectBtn(index, data) {
+      this.selected.splice(0)
+      this.selected.push(data)
     }
   }
 }


### PR DESCRIPTION
## 为什么提PR？
因为当前table不支持单选，故提出来
## 尝试方法
如果自己实现呢？如果自己实现，需要写大量的代码。虽然可以实现，但是如果包含很多溢出隐藏及显示Tooltip呢，那么代码写的特别臃肿。那么利用循环呢？不同宽度呢？依然臃肿。
``` js

<el-table
  :data="[]"
 >
  <el-table-column label="" width="50">
     <template slot-scope="scope">
            <el-radio v-model="tableRadio" :label="scope.row" ><i></i
       ></el-radio>
     </template>
   </el-table-column>
   <el-table-column prop="name" label="名称"/> 
   <el-table-column prop="sex" label="性别"/>
</el-table>
````

## 文档
has-radio-select.md

## 解决问题

在项目中很多表格需要单选，且提出这个pr

## 使用场景

- 表格进行单选

## 测试

##### 单选
![has-radio-select](https://s2.ax1x.com/2020/01/10/l4kAZF.gif)

