### PR TITLE
fix: tableAttrs 无法修改 rowClassName 的问题

### DIFF
--- a/docs/is-tree.md
+++ b/docs/is-tree.md
@@ -33,8 +33,17 @@ export default {
       ],
       hasPagination: false,
       isTree: true,
+      tableAttrs: {
+        rowClassName({rowIndex}) {
+          return rowIndex === 2 ? 'is-tree-red' : ''
+        }
+      },
       expandAll: true,
     }
+  },
+  created() {
+    // FYI: styleguide 里面用不了 style block
+    document.querySelector('style').sheet.insertRule('.is-tree-red {color: red}')
   }
 }
 </script>

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -91,7 +91,7 @@
         v-loading="loading"
         v-bind="tableAttrs"
         :data="data"
-        :row-class-name="showRow"
+        :row-class-name="rowClassName"
         @selection-change="selectStrategy.onSelectionChange"
         @select="selectStrategy.onSelect"
         @select-all="selectStrategy.onSelectAll($event, selectable)"
@@ -1219,6 +1219,13 @@ export default {
         }
       })
       return tmp
+    },
+    rowClassName(...args) {
+      let rcn =
+        this.tableAttrs.rowClassName || this.tableAttrs['row-class-name'] || ''
+      if (typeof rcn === 'function') rcn = rcn(...args)
+      if (this.isTree) rcn += ' ' + this.showRow(...args)
+      return rcn
     },
     showRow({row}) {
       const show = !row.parent || (row.parent._expanded && row.parent._show)


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
fix #283 

## How
原有的 showRow 方法是用来展现一个 toggle 的动画的；现在的处理是合并该逻辑与用户通过 tableAttrs 传进来的逻辑

## Test
https://deploy-preview-284--el-data-table.netlify.com/#/Demo/is-tree?q=size~999,page~1,
```js
// is-tree.md
export default {
  data: function() {
    return {
      isTree: true,
      tableAttrs: {
        rowClassName({rowIndex}) {
          return rowIndex === 2 ? 'is-tree-red' : ''
        }
      },
    }
  },
  created() {
    // FYI: styleguide 里面用不了 style block
    document.querySelector('style').sheet.insertRule('.is-tree-red {color: red}')
  }
}
```
### Before
![image](https://user-images.githubusercontent.com/19591950/74132649-f833d680-4c21-11ea-8ebf-7bfb494978e4.png)

### After
![image](https://user-images.githubusercontent.com/19591950/74132592-ddf9f880-4c21-11ea-8cbe-ecd224f4994e.png)

