### PR TITLE
fix: 查询值为数组时的持久化问题

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -36,6 +36,30 @@ export default {
           label: '姓名',
           id: 'name',
           type: 'input'
+        },
+        {
+          el: {placeholder: '请输入',multiple:true},
+          label: '区域',
+          id: 'area',
+          type: 'select',
+          options:[
+            {
+              label:'东区',
+              value:'east',
+            },
+            {
+              label:'南区',
+              value:'south',
+            }
+            ,{
+              label:'西区',
+              value:'west',
+            },
+            {
+              label:'北区',
+              value:'north',
+            }
+          ],
         }
       ],
       hasView: true

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -946,7 +946,7 @@ export default {
       query = Object.keys(query)
         .filter(k => !isFalsey(query[k]))
         .reduce((obj, k) => {
-          obj[k] = query[k].toString().trim()
+          obj[k] = query[k]
           return obj
         }, {})
 

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -19,7 +19,7 @@ export function stringify(
   delimiter = paramSeparator
 ) {
   return Object.keys(query)
-    .map(k => `${k}${equal}${encodeURIComponent(query[k])}`)
+    .map(k => `${k}${equal}${encodeURIComponent(JSON.stringify(query[k]))}`)
     .join(delimiter)
 }
 
@@ -42,7 +42,7 @@ export function parse(
     .split(delimiter)
     .map(param => param.split(equal))
     .reduce((obj, [k, v]) => {
-      obj[k] = decodeURIComponent(v)
+      obj[k] = JSON.parse(decodeURIComponent(v))
       return obj
     }, {})
 }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -12,7 +12,9 @@ import {
 const query = {
   obj: {a: '1', b: 'b&c'},
   str(equal = valueSeparator, delimiter = paramSeparator) {
-    return `a${equal}1${delimiter}b${equal}${encodeURIComponent('b&c')}`
+    return `a${equal}${encodeURIComponent(
+      JSON.stringify('1')
+    )}${delimiter}b${equal}${encodeURIComponent(JSON.stringify('b&c'))}`
   }
 }
 const routerModes = ['history', 'hash']


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
当查询值为数组时，经过 queryUtil 后会将整个数组变成字符串，例如：
```js
const value = [1,2,3,4]

const queryValue = value.toString().trim() // 1,2,3,4

const stringifyValue = encodeURIComponent(queryValue) // 1%2C2%2C3%2C4

const parseValue = decodeURIComponent(stringifyValue) // 1,2,3,4
```

## How
在 encode 前先把值进行 JSON.stringify()，在 decode 后进行 JSON.parse()，同时把 JSON.stringify 放到 queryUtil 内部处理，则外部不再需要进行额外处理
```js
const value = [1,2,3,4]

const stringifyValue = encodeURIComponent(JSON.stringify(queryValue)) // %5B1%2C2%2C3%2C4%5D

const parseValue = JSON.parse(decodeURIComponent(stringifyValue)) //  [1, 2, 3, 4]
```

## Test

### before
![2020-05-08 14 21 07](https://user-images.githubusercontent.com/27952659/81378748-6bbe8480-913a-11ea-8276-3c316d0b0470.gif)
### after
![2020-05-08 14 18 09](https://user-images.githubusercontent.com/27952659/81378682-46317b00-913a-11ea-90aa-f7111d0c7fe4.gif)

## Docs
- 在 basic.md 添加可多选的示例