### PR TITLE
fix: 查询值为数组时的分隔符问题

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -951,7 +951,10 @@ export default {
         }, {})
 
       const queryStr =
-        (url.indexOf('?') > -1 ? '&' : '?') + queryUtil.URLStringify(query)
+        (url.indexOf('?') > -1 ? '&' : '?') +
+        Object.keys(query)
+          .map(k => `${k}=${decodeURIComponent(query[k])}`)
+          .join('&')
 
       // 请求开始
       this.loading = loading

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -951,8 +951,7 @@ export default {
         }, {})
 
       const queryStr =
-        (url.indexOf('?') > -1 ? '&' : '?') +
-        queryUtil.stringify(query, '=', '&')
+        (url.indexOf('?') > -1 ? '&' : '?') + queryUtil.URLStringify(query)
 
       // 请求开始
       this.loading = loading

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -5,22 +5,6 @@ export const queryFlag = 'q='
 export const queryPattern = new RegExp(queryFlag + '.*' + paramSeparator)
 
 /**
- * 转换query对象成可附在url上的字符串
- * qs.stringify只能自定义delimiter，不能自定义equal
- * {a: 'a&b', b: true, d: [1,2,3]} => 'a=a%26b&b=true&d=1%2C2%2C3'
- *
- * @param {object} query
- * @param {string} equal - 键和值的分隔符
- * @param {string} delimiter - 键值对之间的分隔符
- * @return {string}
- */
-export function URLStringify(query, equal = '=', delimiter = '&') {
-  return Object.keys(query)
-    .map(k => `${k}${equal}${encodeURIComponent(query[k])}`)
-    .join(delimiter)
-}
-
-/**
  * 在浏览器地址栏的 URL 需要做额外处理：兼容持久化数组
  * 直接将数组 encode 和 JSON.stringify 会在刷新时自动 decode，解决方法：改变数组的分隔符
  * {a: 'a&b', b: true, d: [1,2,3]} => 'a~a%26b,b~true,d~%5B1%7C2%7C3%5D'

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -68,7 +68,9 @@ export function parse(
     .map(param => param.split(equal))
     .reduce((obj, [k, v]) => {
       // 替换回逗号
-      const value = decodeURIComponent(v).split(arrayDelimiter)
+      const value = decodeURIComponent(v)
+        .split(arrayDelimiter)
+        .join(',')
       obj[k] = JSON.parse(value)
       return obj
     }, {})

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,8 +1,10 @@
 import {
   valueSeparator,
   paramSeparator,
+  paramInnerSeparator,
   queryFlag,
   stringify,
+  URLStringify,
   parse,
   set,
   get,
@@ -10,13 +12,32 @@ import {
 } from '../src/utils/query'
 
 const query = {
-  obj: {a: '1', b: 'b&c'},
-  str(equal = valueSeparator, delimiter = paramSeparator) {
-    return `a${equal}${encodeURIComponent(
-      JSON.stringify('1')
-    )}${delimiter}b${equal}${encodeURIComponent(JSON.stringify('b&c'))}`
+  obj: {a: '1', b: 'b&c', d: ['1', '2', '3']},
+  str(
+    equal = valueSeparator,
+    delimiter = paramSeparator,
+    arrayDelimiter = paramInnerSeparator
+  ) {
+    return [
+      `a${equal}${encodeURIComponent(JSON.stringify('1'))}`,
+      `b${equal}${encodeURIComponent(JSON.stringify('b&c'))}`,
+      `d${equal}${encodeURIComponent(
+        JSON.stringify(['1', '2', '3'])
+          .split(',')
+          .join(arrayDelimiter)
+      )}`
+    ].join(`${delimiter}`)
+  },
+  URLStr(equal = '=', delimiter = '&') {
+    const encode = val => encodeURIComponent(val)
+    return [
+      `a${equal}${encode('1')}`,
+      `b${equal}${encode('b&c')}`,
+      `d${equal}${encode(['1', '2', '3'])}`
+    ].join(`${delimiter}`)
   }
 }
+
 const routerModes = ['history', 'hash']
 const locations = (() => {
   const origin = 'https://a.b'
@@ -59,11 +80,24 @@ describe('测试 stringify', () => {
   test('基本功能', () => {
     expect(stringify(query.obj)).toBe(query.str())
   })
+  test('自定义 equal & delimiter & arrayDelimiter', () => {
+    const equal = '='
+    const delimiter = '&'
+    const arrayDelimiter = '$'
+    const str = query.str(equal, delimiter, arrayDelimiter)
+    expect(stringify(query.obj, equal, delimiter, arrayDelimiter)).toBe(str)
+  })
+})
+
+describe('测试 URLStringify', () => {
+  test('基本功能', () => {
+    expect(URLStringify(query.obj)).toBe(query.URLStr())
+  })
   test('自定义 equal & delimiter', () => {
     const equal = '='
     const delimiter = '&'
-    const str = query.str(equal, delimiter)
-    expect(stringify(query.obj, equal, delimiter)).toBe(str)
+    const str = query.URLStr(equal, delimiter)
+    expect(URLStringify(query.obj, equal, delimiter)).toBe(str)
   })
 })
 

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -4,7 +4,6 @@ import {
   paramInnerSeparator,
   queryFlag,
   stringify,
-  URLStringify,
   parse,
   set,
   get,
@@ -26,14 +25,6 @@ const query = {
           .split(',')
           .join(arrayDelimiter)
       )}`
-    ].join(`${delimiter}`)
-  },
-  URLStr(equal = '=', delimiter = '&') {
-    const encode = val => encodeURIComponent(val)
-    return [
-      `a${equal}${encode('1')}`,
-      `b${equal}${encode('b&c')}`,
-      `d${equal}${encode(['1', '2', '3'])}`
     ].join(`${delimiter}`)
   }
 }
@@ -86,18 +77,6 @@ describe('测试 stringify', () => {
     const arrayDelimiter = '$'
     const str = query.str(equal, delimiter, arrayDelimiter)
     expect(stringify(query.obj, equal, delimiter, arrayDelimiter)).toBe(str)
-  })
-})
-
-describe('测试 URLStringify', () => {
-  test('基本功能', () => {
-    expect(URLStringify(query.obj)).toBe(query.URLStr())
-  })
-  test('自定义 equal & delimiter', () => {
-    const equal = '='
-    const delimiter = '&'
-    const str = query.URLStr(equal, delimiter)
-    expect(URLStringify(query.obj, equal, delimiter)).toBe(str)
   })
 })
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
因未知原因（可能是 vue-router?）会将 地址栏 url 自动 decode，此时如果存在数组值，则会在 parse 时先被按 `,` 分割，导致无法正常解析：
```js
let url = `q=area~east%2Csouth,size~20,page~1,`

// 刷新时会被自动转换为：

url = `q=area~east,south,size~20,page~1,`

// queryUtil.parse() 方法会先按 ',' 进行分割，导致原本属于同一个字段的值丢失了，就无法正常解析了

url.split(',') // ["q=area~east", "south", "size~20", "page~1", ""]

```
## How
encode 数组值时，先使用别的分隔符；
同时由于之前发送请求和构造地址栏的 url 用的是同一个方法，但现在由于两者 stringify 的方式不一样，所以增加一个 `URLStringify` 用于构造发送 axios 请求的参数

## Test
- 新增 URLStringify 测试用例
- 新增数组 stringify 测试用例