### PR TITLE
fix: 增加searchForm 的空数组进行判断

### DIFF
--- a/src/utils/is-falsey.js
+++ b/src/utils/is-falsey.js
@@ -1,1 +1,3 @@
-export default value => ['', undefined, null].indexOf(value) > -1
+export default value =>
+  ['', undefined, null].indexOf(value) > -1 ||
+  (Array.isArray(value) && value.length === 0)

--- a/src/utils/select-strategy.js
+++ b/src/utils/select-strategy.js
@@ -14,7 +14,16 @@ class StrategyAbstract {
     this.onSelectAll = this.onSelectAll.bind(this)
   }
   get elTable() {
-    return this.elDataTable.$refs.table
+    return (
+      this.elDataTable.$refs.table || {
+        onSelectionChange() {},
+        onSelect() {},
+        onSelectAll() {},
+        toggleRowSelection() {},
+        clearSelection() {},
+        updateElTableSelection() {}
+      }
+    )
   }
   onSelectionChange() {}
   onSelect() {}

--- a/test/is-falsey.test.js
+++ b/test/is-falsey.test.js
@@ -8,6 +8,6 @@ describe('test isFalsey', () => {
     expect(isFalsey()).toBe(true)
     expect(isFalsey(0)).toBe(false)
     expect(isFalsey({})).toBe(false)
-    expect(isFalsey([])).toBe(false)
+    expect(isFalsey([])).toBe(true)
   })
 })


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
Fix #305
## How
searchForm 某个值为空数组时也判断为没有值
![image](https://user-images.githubusercontent.com/19562649/84752431-5584cd80-aff0-11ea-9077-9332c86f428e.png)

当table不存在时代理其方法不让其报错
![image](https://user-images.githubusercontent.com/19562649/84752521-70574200-aff0-11ea-9422-fb64f3f218d8.png)
