### PR TITLE
feat: 兼容 el-table 额外的监听事件

### DIFF
--- a/docs/axios-config.md
+++ b/docs/axios-config.md
@@ -6,8 +6,16 @@ axiosConfig 示例代码，打开控制台，可以看到请求中带上了自�
 </template>
 <script>
 export default {
+  methods: {
+  	rowClick(...args) {
+    	console.log(args)
+    },
+  },
   data() {
     return {
+      tableEventListeners: {
+        'row-click': this.rowClick,
+      },
       axiosConfig: {
         headers: {
           'Authorization': 'Bearer token',

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -93,6 +93,7 @@
         v-bind="tableAttrs"
         :data="data"
         :row-class-name="rowClassName"
+        v-on="tableEventListeners"
         @selection-change="selectStrategy.onSelectionChange"
         @select="selectStrategy.onSelect"
         @select-all="selectStrategy.onSelectAll($event, selectable)"
@@ -637,6 +638,21 @@ export default {
      * @link https://element.eleme.cn/2.4/#/zh-CN/component/table#table-attributes
      */
     tableAttrs: {
+      type: Object,
+      default() {
+        return {}
+      }
+    },
+
+    /**
+     * element table 其他额外的事件监听, 详情配置参考element-ui官网
+     *  tableEventListeners: {
+     *   // key 值必须和 el-table 文档相同的 - 连接模式
+     *   'row-click': rowClick,
+     *  },
+     * @link https://element.eleme.cn/#/zh-CN/component/table#table-events
+     */
+    tableEventListeners: {
       type: Object,
       default() {
         return {}


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
兼容 el-table 额外监听事件
相关 issue
#307 

## How
```js
   /**
     * element table 其他额外的事件监听, 详情配置参考element-ui官网
     *  tableEventListeners: {
     *   // key 值必须和 el-table 文档相同的 - 连接模式
     *   'row-click': rowClick,
     *  },
     * @link https://element.eleme.cn/#/zh-CN/component/table#table-events
     */
    tableEventListeners: {
      type: Object,
      default() {
        return {}
      }
    },
```

```js
    <el-table
        ref="table"
        v-loading="loading"
        v-bind="tableAttrs"
        :data="data"
        :row-class-name="rowClassName"
        v-on="tableEventListeners"
        @selection-change="selectStrategy.onSelectionChange"
        @select="selectStrategy.onSelect"
        @select-all="selectStrategy.onSelectAll($event, selectable)"
      >
```