### PR TITLE
feat: 支持监听 el-table 事件（新增 prop：tableEventHandlers）

### DIFF
--- a/docs/table-attrs.md
+++ b/docs/table-attrs.md
@@ -1,0 +1,27 @@
+通过 tableAttrs 属性，可以直接传 prop 和 eventHandler 到 el-table 本地上
+
+```vue
+<template>
+  <el-data-table v-bind="$data" />
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
+      columns: [
+        {prop: 'date', label: '日期', align: 'center'},
+        {prop: 'name', label: '姓名'},
+        {prop: 'address', label: '地址'},
+      ],
+      tableAttrs: {
+        stripe: true,
+        onRowClick: (row, col, event) => {
+          this.$message.success(`点击 ${row.name}！`)
+        }
+      }
+    }
+  }
+}
+</script>
+```

--- a/docs/table-props-events.md
+++ b/docs/table-props-events.md
@@ -1,4 +1,4 @@
-通过 tableAttrs 属性，可以直接传 prop 和 eventHandler 到 el-table 本地上
+通过 tableAttrs & tableEventHandlers 属性，可以直接传 prop 和 eventHandler 到 el-table 本体上
 
 ```vue
 <template>
@@ -16,10 +16,16 @@ export default {
       ],
       tableAttrs: {
         stripe: true,
-        onRowClick: (row, col, event) => {
+      },
+      tableEventHandlers: {
+        // camel & kebab case 皆可
+        rowClick: (row) => {
           this.$message.success(`点击 ${row.name}！`)
+        },
+        'row-dblclick': (row) => {
+          this.$message.success(`双击点击 ${row.name}！`)
         }
-      }
+      },
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "lodash.get": "^4.4.2",
     "lodash.isempty": "^4.4.0",
+    "lodash.kebabcase": "^4.1.1",
     "lodash.values": "^4.3.0"
   },
   "devDependencies": {

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -93,6 +93,7 @@
         v-bind="tableAttrs"
         :data="data"
         :row-class-name="rowClassName"
+        v-on="tableEventHandlers"
         @selection-change="selectStrategy.onSelectionChange"
         @select="selectStrategy.onSelect"
         @select-all="selectStrategy.onSelectAll($event, selectable)"
@@ -283,6 +284,7 @@
 <script>
 import _get from 'lodash.get'
 import _values from 'lodash.values'
+import _kebabcase from 'lodash.kebabcase'
 import _isEmpty from 'lodash.isempty'
 import SelfLoadingButton from './components/self-loading-button.vue'
 import TheDialog, {dialogModes} from './components/the-dialog.vue'
@@ -633,7 +635,7 @@ export default {
       default: false
     },
     /**
-     * element table 属性设置, 详情配置参考element-ui官网
+     * el-table 的 prop 和 eventHandler 设置, 详情配置参考element-ui官网
      * @link https://element.eleme.cn/2.4/#/zh-CN/component/table#table-attributes
      */
     tableAttrs: {
@@ -813,6 +815,16 @@ export default {
     }
   },
   computed: {
+    tableEventHandlers() {
+      const handlers = {}
+      for (const key in this.tableAttrs) {
+        const kebab = _kebabcase(key)
+        if (kebab.startsWith('on-')) {
+          handlers[kebab.slice(3)] = this.tableAttrs[key]
+        }
+      }
+      return handlers
+    },
     hasSelect() {
       return this.columns.length && this.columns[0].type == 'selection'
     },

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -93,7 +93,7 @@
         v-bind="tableAttrs"
         :data="data"
         :row-class-name="rowClassName"
-        v-on="tableEventHandlers"
+        v-on="tableEventHandlersInner"
         @selection-change="selectStrategy.onSelectionChange"
         @select="selectStrategy.onSelect"
         @select-all="selectStrategy.onSelectAll($event, selectable)"
@@ -635,10 +635,20 @@ export default {
       default: false
     },
     /**
-     * el-table 的 prop 和 eventHandler 设置, 详情配置参考element-ui官网
+     * el-table 的 prop 配置，详情配置参考element-ui官网
      * @link https://element.eleme.cn/2.4/#/zh-CN/component/table#table-attributes
      */
     tableAttrs: {
+      type: Object,
+      default() {
+        return {}
+      }
+    },
+    /**
+     * el-table 的 eventHandler 配置，详情配置参考element-ui官网
+     * @link https://element.eleme.cn/2.4/#/zh-CN/component/table#table-attributes
+     */
+    tableEventHandlers: {
       type: Object,
       default() {
         return {}
@@ -815,13 +825,11 @@ export default {
     }
   },
   computed: {
-    tableEventHandlers() {
+    tableEventHandlersInner() {
       const handlers = {}
-      for (const key in this.tableAttrs) {
+      for (const key in this.tableEventHandlers) {
         const kebab = _kebabcase(key)
-        if (kebab.startsWith('on-')) {
-          handlers[kebab.slice(3)] = this.tableAttrs[key]
-        }
+        handlers[kebab] = this.tableEventHandlers[key]
       }
       return handlers
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7212,7 +7212,7 @@ lodash.isplainobject@^4.0.6:
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  resolved "https://registry.npm.taobao.org/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
   integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.set@^4.3.2:


### PR DESCRIPTION
## Why
fix #307 
close #308 ，区别是不用新增 prop，而且可以写 camelCase

通过 tableAttrs 支持 el-table 的 prop & eventHandler 的传递

## How
规则是，以 on 开头的 camelCase 属性会作为事件监听器传入

## Test
![image](https://user-images.githubusercontent.com/19591950/86198675-be407e00-bb8a-11ea-82d9-e80e9b62af05.png)
![image](https://user-images.githubusercontent.com/19591950/86198706-ce585d80-bb8a-11ea-85c7-34fcdd9386e8.png)

## Doc
新增 table-attrs.md