### PR TITLE
fix:查询参数为数组时需要将数组转为字符串形式

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -14,8 +14,8 @@
         ref="searchForm"
         :content="_searchForm"
         inline
-        @submit.native.prevent
         class="search-form-container"
+        @submit.native.prevent
       >
         <slot
           v-for="slot in searchLocatedSlotKeys"
@@ -966,7 +966,15 @@ export default {
       // 无效值过滤，注意0是有效值
       query = Object.keys(query)
         .filter(k => !isFalsey(query[k]))
-        .reduce((obj, k) => ((obj[k] = query[k]), obj), {})
+        .reduce(
+          (obj, k) => (
+            (obj[k] = Array.isArray(query[k])
+              ? query[k].toString().trim()
+              : query[k]),
+            obj
+          ),
+          {}
+        )
 
       // 请求开始
       this.loading = loading

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -978,7 +978,7 @@ export default {
         history.replaceState(history.state, 'el-data-table search', newUrl)
       }
 
-      // 处理查询参数为数组时，将数组转为字符串
+      // 当查询参数为数组时，需要将参数转化为字符串才发送请求
       query = Object.keys(query).reduce(
         (obj, k) => (
           (obj[k] = Array.isArray(query[k])

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -966,15 +966,7 @@ export default {
       // 无效值过滤，注意0是有效值
       query = Object.keys(query)
         .filter(k => !isFalsey(query[k]))
-        .reduce(
-          (obj, k) => (
-            (obj[k] = Array.isArray(query[k])
-              ? query[k].toString().trim()
-              : query[k]),
-            obj
-          ),
-          {}
-        )
+        .reduce((obj, k) => ((obj[k] = query[k]), obj), {})
 
       // 请求开始
       this.loading = loading
@@ -985,6 +977,18 @@ export default {
         const newUrl = queryUtil.set(location.href, query, this.routerMode)
         history.replaceState(history.state, 'el-data-table search', newUrl)
       }
+
+      // 处理查询参数为数组时，将数组转为字符串
+      query = Object.keys(query).reduce(
+        (obj, k) => (
+          (obj[k] = Array.isArray(query[k])
+            ? query[k].toString().trim()
+            : query[k]),
+          obj
+        ),
+        {}
+      )
+
       const config = {
         ...this.axiosConfig,
         params: {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
当查询参数为数组时，需要将参数转化为字符串。因为在发送请求时，数组参数会被处理；列如：
``` js
const query = {
  area: ['south','west']
}

//会变成
const query = {
  area[]: 'south',
  area[]: 'west'
}
``` 
在大多数项目中已使用数组参数，都转化为了字符串的形式。会导致查询接口报错。

## How
只需在处理query参数时，加上一个判断，如果是使用的数组，那么将数组转化为字符串即可
``` js
const area = ['south','west']
const areaString = area.toString().trim()   // south,west
``` 
## Test
### before
![before](https://user-images.githubusercontent.com/22702128/88244533-b45ff580-ccc6-11ea-8c4b-1cd77e2580a9.gif)

### after


![after](https://user-images.githubusercontent.com/22702128/88244767-5c75be80-ccc7-11ea-8e4a-665e7b95931c.gif)


