### PR TITLE
fix: 修复 searchForm 刷新后恢复默认值的问题

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -294,7 +294,7 @@ import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
 import getLocatedSlotKeys from './utils/extract-keys'
 import transformSearchImmediatelyItem from './utils/search-immediately-item'
-import {isFalsey, dealQuery} from './utils/is-falsey'
+import {isFalsey, removeEmptyKeys} from './utils/utils'
 
 const defaultFirstPage = 1
 const noPaginationDataPath = 'payload'
@@ -992,7 +992,7 @@ export default {
       const config = {
         ...this.axiosConfig,
         params: {
-          ...dealQuery(query),
+          ...removeEmptyKeys(query),
           ..._get(this.axiosConfig, 'params', {})
         }
       }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -294,7 +294,7 @@ import * as queryUtil from './utils/query'
 import getSelectStrategy from './utils/select-strategy'
 import getLocatedSlotKeys from './utils/extract-keys'
 import transformSearchImmediatelyItem from './utils/search-immediately-item'
-import isFalsey from './utils/is-falsey'
+import {isFalsey, dealQuery} from './utils/is-falsey'
 
 const defaultFirstPage = 1
 const noPaginationDataPath = 'payload'
@@ -992,7 +992,7 @@ export default {
       const config = {
         ...this.axiosConfig,
         params: {
-          ...query,
+          ...dealQuery(query),
           ..._get(this.axiosConfig, 'params', {})
         }
       }

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -965,7 +965,7 @@ export default {
 
       // 无效值过滤，注意0是有效值
       query = Object.keys(query)
-        .filter(k => !isFalsey(query[k]))
+        .filter(k => ![undefined, null].includes(query[k]))
         .reduce((obj, k) => ((obj[k] = query[k]), obj), {})
 
       // 请求开始

--- a/src/utils/is-falsey.js
+++ b/src/utils/is-falsey.js
@@ -1,4 +1,6 @@
-export const isFalsey = value => [undefined, null].includes(value)
+export const isFalsey = value =>
+  ['', undefined, null].indexOf(value) > -1 ||
+  (Array.isArray(value) && value.length === 0)
 
 export const dealQuery = query =>
   Object.keys(query)

--- a/src/utils/is-falsey.js
+++ b/src/utils/is-falsey.js
@@ -1,3 +1,11 @@
-export default value =>
-  ['', undefined, null].indexOf(value) > -1 ||
-  (Array.isArray(value) && value.length === 0)
+export const isFalsey = value => [undefined, null].includes(value)
+
+export const dealQuery = query =>
+  Object.keys(query)
+    .filter(k => {
+      const value = query[k]
+      return Array.isArray(value)
+        ? value.length !== 0
+        : !['', undefined, null].includes(value)
+    })
+    .reduce((obj, k) => ((obj[k] = query[k]), obj), {})

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -2,7 +2,7 @@ export const isFalsey = value =>
   ['', undefined, null].indexOf(value) > -1 ||
   (Array.isArray(value) && value.length === 0)
 
-export const dealQuery = query =>
+export const removeEmptyKeys = query =>
   Object.keys(query)
     .filter(k => {
       const value = query[k]

--- a/test/is-falsey.test.js
+++ b/test/is-falsey.test.js
@@ -4,11 +4,11 @@ describe('test isFalsey', () => {
   test('判断为 "",undefined或者 null', () => {
     expect(isFalsey(undefined)).toBe(true)
     expect(isFalsey(null)).toBe(true)
-    expect(isFalsey('')).toBe(false)
+    expect(isFalsey('')).toBe(true)
     expect(isFalsey()).toBe(true)
     expect(isFalsey(0)).toBe(false)
     expect(isFalsey({})).toBe(false)
-    expect(isFalsey([])).toBe(false)
+    expect(isFalsey([])).toBe(true)
   })
 })
 

--- a/test/is-falsey.test.js
+++ b/test/is-falsey.test.js
@@ -1,13 +1,28 @@
-import isFalsey from '../src/utils/is-falsey'
+import {isFalsey, dealQuery} from '../src/utils/is-falsey'
 
 describe('test isFalsey', () => {
   test('判断为 "",undefined或者 null', () => {
     expect(isFalsey(undefined)).toBe(true)
     expect(isFalsey(null)).toBe(true)
-    expect(isFalsey('')).toBe(true)
+    expect(isFalsey('')).toBe(false)
     expect(isFalsey()).toBe(true)
     expect(isFalsey(0)).toBe(false)
     expect(isFalsey({})).toBe(false)
-    expect(isFalsey([])).toBe(true)
+    expect(isFalsey([])).toBe(false)
+  })
+})
+
+describe('test dealQuery', () => {
+  test('判断 "", undefined, null, 空数组', () => {
+    expect(
+      dealQuery({
+        a: 1,
+        b: '',
+        c: undefined,
+        d: null,
+        e: [],
+        f: [2]
+      })
+    ).toStrictEqual({a: 1, f: [2]})
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,10 +12,10 @@ describe('test isFalsey', () => {
   })
 })
 
-describe('test dealQuery', () => {
+describe('test removeEmptyKeys', () => {
   test('判断 "", undefined, null, 空数组', () => {
     expect(
-      dealQuery({
+      removeEmptyKeys({
         a: 1,
         b: '',
         c: undefined,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-import {isFalsey, dealQuery} from '../src/utils/is-falsey'
+import {isFalsey, removeEmptyKeys} from '../src/utils/utils'
 
 describe('test isFalsey', () => {
   test('判断为 "",undefined或者 null', () => {


### PR DESCRIPTION
## Why
fix #319 

## How
Describe your steps:
1. 当搜索表单中搜索字段有默认值时，进入页面，搜索时传入默认值，url同步数据
2. 当搜索字段的默认值被清空时，url同步数据，并且刷新页面搜索时不会被默认值覆盖（搜索时不传入数据）


## Test
> 原来的数据为空的逻辑判断，认为空数组，空字符为isFalsey，现改为not false

- before
```js
import isFalsey from '../src/utils/is-falsey'

describe('test isFalsey', () => {
  test('判断为 "",undefined或者 null', () => {
    expect(isFalsey(undefined)).toBe(true)
    expect(isFalsey(null)).toBe(true)
    expect(isFalsey('')).toBe(true)
    expect(isFalsey()).toBe(true)
    expect(isFalsey(0)).toBe(false)
    expect(isFalsey({})).toBe(false)
    expect(isFalsey([])).toBe(true)
  })
})
```
- after
```js
import {isFalsey, dealQuery} from '../src/utils/is-falsey'

describe('test isFalsey', () => {
  test('判断为 "",undefined或者 null', () => {
    expect(isFalsey(undefined)).toBe(true)
    expect(isFalsey(null)).toBe(true)
    expect(isFalsey('')).toBe(false)
    expect(isFalsey()).toBe(true)
    expect(isFalsey(0)).toBe(false)
    expect(isFalsey({})).toBe(false)
    expect(isFalsey([])).toBe(false)
  })
})

describe('test dealQuery', () => {
  test('判断 "", undefined, null, 空数组', () => {
    expect(
      dealQuery({
        a: 1,
        b: '',
        c: undefined,
        d: null,
        e: [],
        f: [2]
      })
    ).toStrictEqual({a: 1, f: [2]})
  })
})
```

