### PR TITLE
fix: 支持在 axiosConfig 中定义请求方法

### DIFF
--- a/docs/axios-config.md
+++ b/docs/axios-config.md
@@ -12,7 +12,8 @@ export default {
         headers: {
           'Authorization': 'Bearer token',
           'X-TOKEN': 'X-TOKEN'
-        }
+        },
+        method: 'post'
       },
       url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
       columns: [

--- a/docs/axios-config.md
+++ b/docs/axios-config.md
@@ -13,7 +13,7 @@ export default {
           'Authorization': 'Bearer token',
           'X-TOKEN': 'X-TOKEN'
         },
-        method: 'post'
+        // method: 'post' // 指定请求方式为 post
       },
       url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
       columns: [

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -989,16 +989,17 @@ export default {
         {}
       )
 
-      const config = {
-        ...this.axiosConfig,
-        params: {
-          ...removeEmptyKeys(query),
-          ..._get(this.axiosConfig, 'params', {})
-        }
+      const params = {
+        ...removeEmptyKeys(query),
+        ..._get(this.axiosConfig, 'params', {})
       }
 
-      this.$axios
-        .get(url, config)
+      this.$axios({
+        method: 'get',
+        url,
+        params,
+        ...this.axiosConfig
+      })
         .then(({data: resp}) => {
           let data = []
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
方便对请求进行扩展

## How
在使用组件时，默认请求方式是 get，在 axiosConfig 中添加 method: 'post' 即可修改为 post

## Docs

更新 axiosConfig.md 文档
