### PR TITLE
fix: 使用默认删除方法提供loading状态

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1180,7 +1180,7 @@ export default {
      * @param {object|object[]} - 要删除的数据对象或数组
      */
     onDefaultDelete(data) {
-      this.$confirm(this.deleteMessage(data), '提示', {
+      return this.$confirm(this.deleteMessage(data), '提示', {
         type: 'warning',
         confirmButtonClass: 'el-button--danger',
         beforeClose: async (action, instance, done) => {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
```js
{
  text: "删除",
  type: "danger",
  atClick: async (row) => {
    await this.$refs.routerTable.onDefaultDelete(row)
    return false
  },
}
```
配置 extraButtons 时，使用了内部的 onDefaultDelete 方法，但没有正确显示 self-loading-button 的 loading 状态

## How
onDefaultDelete 方法返回 Promise

