### PR TITLE
fix(text-button):  操作栏按钮的色值可能会取值不正确  #335

### DIFF
--- a/src/components/text-button.vue
+++ b/src/components/text-button.vue
@@ -17,7 +17,8 @@ export default {
       style: {
         border: 'none',
         background: 'inherit',
-        padding: '9px 0'
+        padding: '9px 0',
+        color: ''
       }
     }
   },
@@ -29,15 +30,8 @@ export default {
   },
   methods: {
     // 将 color 写到 style 里是为了覆盖 hover 效果
-    async fixHoverColor() {
-      const {style} = this
-      delete style.color
-      this.style = {...style}
-      await new Promise(r => setTimeout(r, 300))
-      this.style = {
-        ...style,
-        color: getComputedStyle(this.$el).color
-      }
+    fixHoverColor() {
+      this.style.color = getComputedStyle(this.$el).color
     }
   }
 }

--- a/src/components/text-button.vue
+++ b/src/components/text-button.vue
@@ -18,7 +18,8 @@ export default {
         border: 'none',
         background: 'inherit',
         padding: '9px 0',
-        color: ''
+        color: '',
+        pointerEvents: ''
       }
     }
   },
@@ -26,12 +27,16 @@ export default {
     '$attrs.disabled': 'fixHoverColor'
   },
   mounted() {
-    this.fixHoverColor()
+    this.style.color = getComputedStyle(this.$el).color
   },
   methods: {
     // 将 color 写到 style 里是为了覆盖 hover 效果
-    fixHoverColor() {
+    async fixHoverColor() {
+      this.style.color = ''
+      this.style.pointerEvents = 'none'
+      await new Promise(r => setTimeout(r, 300))
       this.style.color = getComputedStyle(this.$el).color
+      this.style.pointerEvents = ''
     }
   }
 }


### PR DESCRIPTION

fix #335

### 优化代码逻辑

1. this.style是响应式对象且已绑定到模板里面，故32-35行代码貌似做了无用功？
2. mounted时node已挂载，getComputedStyle(this.$el).color也就可以取到值，sleep 300s反而会造成取color值不对的几率

![image](https://user-images.githubusercontent.com/20294811/115911334-88b1ac00-a4a0-11eb-86bb-c029ac4b2d8d.png)

### test：

![image](https://user-images.githubusercontent.com/20294811/115910730-c6fa9b80-a49f-11eb-9418-8a85d484a099.png)
