### PR TITLE
feat: slot=operation，适用于 extraButtons 不满足需求时

### DIFF
--- a/docs/slot-operation.md
+++ b/docs/slot-operation.md
@@ -1,0 +1,55 @@
+operation插槽，作用域传入当前行 row
+
+```vue
+<template>
+  <el-data-table
+    v-bind="$data"
+  >
+    <template v-slot:operation="{row}">
+      <el-button @click="click(row)" type="text">点击查看控制台</el-button>
+      <el-dropdown>
+        <el-button type="primary" size="small">
+          更多菜单<i class="el-icon-arrow-down el-icon--right"></i>
+        </el-button>
+        <el-dropdown-menu slot="dropdown">
+          <el-dropdown-item>黄金糕</el-dropdown-item>
+          <el-dropdown-item>狮子头</el-dropdown-item>
+          <el-dropdown-item>螺蛳粉</el-dropdown-item>
+          <el-dropdown-item>双皮奶</el-dropdown-item>
+          <el-dropdown-item>蚵仔煎</el-dropdown-item>
+        </el-dropdown-menu>
+      </el-dropdown>
+    </template>
+  </el-data-table>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      url: 'https://mockapi.eolinker.com/IeZWjzy87c204a1f7030b2a17b00f3776ce0a07a5030a1b/el-data-table?q=basic',
+      hasNew: false,
+      columns: [
+        {prop: 'date', label: '日期'},
+        {prop: 'name', label: '姓名'},
+        {prop: 'address', label: '地址'},
+      ],
+      extraButtons: [
+        {
+          type: 'success',
+          disabled: row => row.date === '2016-05-04',
+          text: row => row.status === 'normal' ? '禁用' : '启用',
+          atClick(row) {
+            alert(row.name)
+          }
+        },
+      ]
+    }
+  },
+  methods: {
+    click(row) {
+      console.log(row)
+    }
+  }
+}
+</script>
+```

--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -71,10 +71,10 @@
             >{{ deleteText }}</el-button
           >
 
-          <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，作用域传入selected -->
+          <!--@slot 额外的header内容, 当headerButtons不满足需求时可以使用，传入selected -->
           <slot name="header" :selected="selected" />
 
-          <!--@collapse 自定义折叠按钮, 默认的样式文案不满足时可以使用，scope 默认返回当前折叠状态 Boolean -->
+          <!--@collapse 自定义折叠按钮, 默认的样式文案不满足时可以使用。传入当前折叠状态 isSearchCollapse: Boolean -->
           <slot name="collapse" :isSearchCollapse="isSearchCollapse">
             <el-button
               v-if="canSearchCollapse"
@@ -243,10 +243,13 @@
             >
               {{ deleteText }}
             </self-loading-button>
+
+            <!--@slot 自定义操作列, 当extraButtons不满足需求时可以使用。传入 row -->
+            <slot name="operation" :row="scope.row" />
           </template>
         </el-data-table-column>
 
-        <!--@slot 自定义操作列, 当extraButtons不满足需求时可以使用 -->
+        <!--@slot 默认slot，同 el-table -->
         <slot />
       </el-table>
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
当 extraButtons 存在，但不完全满足需求时，需要写 template。希望原有 extraButtons 不用改写成 template

## How
添加 slot=operation

## Test

示例代码：
![image](https://user-images.githubusercontent.com/9384365/129830531-d793b5f0-8ea0-41e0-9cc2-1242eef34b4d.png)

展示效果：
![image](https://user-images.githubusercontent.com/9384365/129830555-d70d2bbd-18f0-421d-a7da-dcf3bd10dfd3.png)


## Docs
yes
