### PR TITLE
fix: el-data-table树翻页页码不显示错误

### DIFF
--- a/src/el-data-table.vue
+++ b/src/el-data-table.vue
@@ -1056,6 +1056,7 @@ export default {
           // 树形结构逻辑
           if (this.isTree) {
             this.data = this.tree2Array(data, this.expandAll)
+            this.total = total //树翻页总数
           } else {
             this.data = data
             this.total = total


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
el-data-table在树形结构列表展示的是，如果显示翻页翻页页码不显示

## How
Describe your steps:
1.  在设置翻页的情况下，设置翻页属性不起作用

You may use xmind or other mind map to show you logic

 

## Docs
It there requires a change to the documentation？
